### PR TITLE
Fix compatibility issues and add locking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.mailadm.lock

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def main():
         author='holger',
         author_email='holger@merlinux.eu',
         package_dir={'': 'src'},
-        packages = setuptools.find_packages('src'),
+        packages=setuptools.find_packages('src'),
         classifiers=['Development Status :: 4 - Beta',
                      'Intended Audience :: Developers',
                      'License :: OSI Approved :: MIT License',
@@ -30,7 +30,12 @@ def main():
             [console_scripts]
             mailadm=mailadm.cmdline:mailadm_main
         ''',
-        install_requires = ["flask", "click>=6.0", "iniconfig>=1.0"],
+        install_requires=[
+            "click>=6.0",
+            "fasteners",
+            "flask",
+            "iniconfig>=1.0",
+        ],
         zip_safe=False,
     )
 

--- a/src/mailadm/mail.py
+++ b/src/mailadm/mail.py
@@ -160,7 +160,9 @@ class MailController:
         with self.modify_lines(mc.path_dovecot_users) as lines:
             for line in lines:
                 assert not line.startswith(email), line
-            line = f"{email}:{hash_pw}:{mc.dovecot_uid}:{mc.dovecot_gid}::{mc.path_vmaildir}::"
+            line = (
+                "{email}:{hash_pw}:{mc.dovecot_uid}:{mc.dovecot_gid}::"
+                "{mc.path_vmaildir}::".format(**locals()))
             self.log("adding line to users")
             self.log(line)
             lines.append(line)
@@ -168,7 +170,7 @@ class MailController:
         with self.modify_lines(mc.path_virtual_mailboxes, pm=True) as lines:
             for line in lines:
                 assert not line.startswith(email), line
-            lines.append(f"{email} {email}")
+            lines.append("{email} {email}".format(**locals()))
 
         p = os.path.join(mc.path_vmaildir, email)
         self.log("vmaildir:", p)

--- a/src/mailadm/mail.py
+++ b/src/mailadm/mail.py
@@ -155,7 +155,7 @@ class MailController:
         if password is None:
             password = self.gen_password()
         hash_pw = subprocess.check_output(
-            ["/usr/bin/doveadm", "pw", "-s", "SHA512-CRYPT", "-p", password])
+            ["doveadm", "pw", "-s", "SHA512-CRYPT", "-p", password])
         return password, hash_pw.decode("ascii").strip()
 
     def gen_password(self):
@@ -166,4 +166,4 @@ class MailController:
     def postmap(self, path):
         print("postmap", path)
         if not self.dryrun:
-            subprocess.check_call(["/usr/sbin/postmap", path])
+            subprocess.check_call(["postmap", path])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,9 @@ def make_ini_from_values(make_ini, tmpdir):
         path_dovecot_users=None,
         path_virtual_mailboxes=None,
         path_vmaildir=None,
+        path_mailadm_db=None,
+        dovecot_uid=1000,
+        dovecot_gid=2000,
     ):
         path = tmpdir.mkdir(name)
         if path_dovecot_users is None:
@@ -97,6 +100,8 @@ def make_ini_from_values(make_ini, tmpdir):
             path_virtual_mailboxes = path.ensure("path_virtual_mailboxes")
         if path_vmaildir is None:
             path_vmaildir = path.ensure("path_vmaildir", dir=1)
+        if path_mailadm_db is None:
+            path_mailadm_db = path.ensure("path_mailadm_db")
 
         return make_ini("""
             [token:{name}]
@@ -104,9 +109,12 @@ def make_ini_from_values(make_ini, tmpdir):
             expiry = {expiry}
             path_virtual_mailboxes = {path_virtual_mailboxes}
             path_dovecot_users = {path_dovecot_users}
+            path_mailadm_db = {path_mailadm_db}
             path_vmaildir = {path_vmaildir}
             webdomain = {webdomain}
             domain = {domain}
             prefix = {prefix}
+            dovecot_uid = {dovecot_uid}
+            dovecot_gid = {dovecot_gid}
         """.format(**locals()))
     return make_ini_from_values


### PR DESCRIPTION
There were a few compatibility issues, e.g. with absolute paths to programs where are at different places on NixOS. We now expect those programs to be in $PATH. This is not a problem as the PATH will be specified in the systemd service file and can be adapted accordingly.

I've also changed asking dovecotadm for a password hash. Python's `crypt` is perfectly sufficient as it creates a compatible hash and uses the strongest hash available by default.

I had to add another file "userdb" which formerly was included in the postfix virtual user table. That doesn't work here, as the RHS of the map is actually used. 

Another thing is locking. Methods writing the state files are locked now. I didn't write any test for that, because the code needs to change considerably anyway, e.g. to use a database.