### PR TITLE
make venv path absolute in case someone logs in with sudo su

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -43,7 +43,7 @@ Create and activate a Python virtualenv and install mailadm::
     venv/bin/pip install mailadm
 
     # activate venv, and set mailadm config path on login
-    echo "source venv/bin/activate venv" >> .bashrc
+    echo "source ~/venv/bin/activate venv" >> .bashrc
     echo "export MAILADM_CONFIG=\$HOME/mailadm.config" >> .bashrc
 
 Now do `source $HOME/.bashrc` so you have the new settings.


### PR DESCRIPTION
I just tried to login to the mailadm user with `sudo su mailadm` - which gave me the error `bash: venv/bin/activate: No such file or directory`.

It makes sense to make this path absolute, as the location of the script doesn't change, while there *are* situations in which $PWD is not ~.

A very small thing for an unlikely situation, I know. Can be closed without discussion, if anything speaks against it.