### PR TITLE
Fix two small API issues which caused the tests to fail

### DIFF
--- a/src/mailadm/mailcow.py
+++ b/src/mailadm/mailcow.py
@@ -49,7 +49,7 @@ class MailcowConnection:
 
     def get_user(self, addr):
         """HTTP Request to get a specific mailcow user (not only mailadm-generated ones)."""
-        url = self.mailcow_endpoint + "get/mailbox/"
+        url = self.mailcow_endpoint + "get/mailbox/" + addr
         result = r.get(url, headers=self.auth)
         json = result.json()
         if json == {}:
@@ -57,9 +57,7 @@ class MailcowConnection:
         if type(json) == dict:
             if json.get("type") == "error":
                 raise MailcowError(json)
-        for account in json:
-            if account.get("username") == addr:
-                return MailcowUser(account)
+            return MailcowUser(json)
 
     def get_user_list(self):
         """HTTP Request to get all mailcow users (not only mailadm-generated ones)."""

--- a/src/mailadm/web.py
+++ b/src/mailadm/web.py
@@ -33,7 +33,11 @@ def create_app_from_db(db):
                 return jsonify(email=user_info.addr, password=user_info.password,
                                expiry=token_info.expiry, ttl=user_info.ttl)
             except (DBError, MailcowError) as e:
+                if "does already exist" in str(e):
+                    return jsonify(type="error", status_code=409,
+                                   reason="user already exists in mailcow"), 409
                 if "UNIQUE constraint failed" in str(e):
-                    return jsonify(type="error", status_code=409, reason="user already exists"), 409
+                    return jsonify(type="error", status_code=409,
+                                   reason="user already exists in mailadm"), 409
                 return jsonify(type="error", status_code=500, reason=str(e)), 500
     return app

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4,7 +4,7 @@ import mailadm
 import random
 
 
-def test_new_user_random(db, monkeypatch):
+def test_new_user_random(db, monkeypatch, mailcow):
     token = "12319831923123"
     with db.write_transaction() as conn:
         conn.add_token(name="test123", token=token, prefix="pytest.", expiry="1w")
@@ -22,6 +22,10 @@ def test_new_user_random(db, monkeypatch):
     r = app.post('/?t=123123&username=hello')
     assert r.status_code == 403
     assert r.json.get("reason") == "token 123123 is invalid"
+
+    # delete a@x.testrun.org and b@x.testrun.org in case earlier tests failed to clean them up
+    mailcow.del_user_mailcow("pytest.a@x.testrun.org")
+    mailcow.del_user_mailcow("pytest.b@x.testrun.org")
 
     chars = list("ab")
 
@@ -46,11 +50,8 @@ def test_new_user_random(db, monkeypatch):
     assert r3.status_code == 409
     assert r3.json.get("reason") == "user already exists"
 
-
-    with db.write_transaction() as conn:
-        mailcow = conn.get_mailcow_connection()
-        mailcow.del_user_mailcow(email)
-        mailcow.del_user_mailcow(r2.json["email"])
+    mailcow.del_user_mailcow(email)
+    mailcow.del_user_mailcow(r2.json["email"])
 
 
 def test_env(db, monkeypatch):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -48,7 +48,7 @@ def test_new_user_random(db, monkeypatch, mailcow):
 
     r3 = app.post('/?t=' + token)
     assert r3.status_code == 409
-    assert r3.json.get("reason") == "user already exists"
+    assert r3.json.get("reason") == "user already exists in mailcow"
 
     mailcow.del_user_mailcow(email)
     mailcow.del_user_mailcow(r2.json["email"])


### PR DESCRIPTION
1. We had a bug in mailcow.get_user(), maybe caused by a mailcow API change (unfortunately the mailcow API is not versioned).
2.  So far we only threw 409 conflict errors on already existing accounts if they were already existing in mailadm, but not in mailcow - the other way round resulted in a 500 error. Now both cases throw a 409 error, but with different json error messages, making it easier to find the reason.