### PR TITLE
running prune thread directly in gunicorn

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,3 @@
+def on_starting(server):
+    from mailadm.app import init_threads
+    init_threads()

--- a/src/mailadm/app.py
+++ b/src/mailadm/app.py
@@ -42,6 +42,8 @@ def watcher():
         threads = threading.enumerate()
         if "prune" in [t.getName() for t in threads]:
             running += 1
+        else:
+            print("prune thread died, killing everything now", file=sys.stderr)
     else:
         os._exit(1)
 

--- a/src/mailadm/app.py
+++ b/src/mailadm/app.py
@@ -31,7 +31,7 @@ def prune():
                         continue
                     print("pruned {} (token {!r})".format(user_info.addr, user_info.token_name),
                           file=sys.stderr)
-        time.sleep(10)
+        time.sleep(600)
 
 
 def watcher():

--- a/src/mailadm/app.py
+++ b/src/mailadm/app.py
@@ -15,8 +15,8 @@ from .conn import DBError
 def prune():
     print("prune thread started", file=sys.stderr)
     db = DB(get_db_path())
-    sysdate = int(time.time())
     while 1:
+        sysdate = int(time.time())
         with db.write_transaction() as conn:
             expired_users = conn.get_expired_users(sysdate)
             if not expired_users:

--- a/src/mailadm/app.py
+++ b/src/mailadm/app.py
@@ -20,20 +20,22 @@ def prune():
         with db.write_transaction() as conn:
             expired_users = conn.get_expired_users(sysdate)
             if not expired_users:
-                print("nothing to prune")
+                print("nothing to prune", file=sys.stderr)
             else:
                 for user_info in expired_users:
                     try:
                         conn.delete_email_account(user_info.addr)
                     except (DBError, MailcowError) as e:
-                        print("failed to delete e-mail account {}: {}".format(user_info.addr, e))
+                        print("failed to delete e-mail account {}: {}".format(user_info.addr, e),
+                              file=sys.stderr)
                         continue
-                    print("{} (token {!r})".format(user_info.addr, user_info.token_name))
+                    print("pruned {} (token {!r})".format(user_info.addr, user_info.token_name),
+                          file=sys.stderr)
         time.sleep(10)
 
 
 def watcher():
-    print("watcher thread started")
+    print("watcher thread started", file=sys.stderr)
     running = 1
     while running == 1:
         running = 0


### PR DESCRIPTION
I figured out a way to run threads from the gunicorn main process. This is a prerequisite for #36. We can use this to run all mailadm threads in the same docker container.

Reference: 
- https://github.com/benoitc/gunicorn/issues/2320#issuecomment-619208001 recommends using gunicorn hooks
- I decided that this one fits better than post_worker_init: https://docs.gunicorn.org/en/stable/settings.html?highlight=post_worker_init#on-starting

I added a small watcher thread which will kill the whole process/container if the prune thread dies. This can be extended to the bot thread when we add it in #23. Also, all our threads are daemon threads - together, this ensures that the whole container dies if any of the gunicorn, prune, or bot threads fails, and can be restarted by docker.

In the long term I want to move the app.prune() function to commands.py or something, but this doesn't exist yet on master, so I just added it to app.py for now. It's a bit against DRY, but let's do this properly after #23 is merged.