### PR TITLE
add --dryrun to mailadm add-user

### DIFF
--- a/src/mailadm/cmdline.py
+++ b/src/mailadm/cmdline.py
@@ -300,6 +300,9 @@ def add_user(ctx, addr, password, token, dryrun):
     elif result["status"] == "success":
         click.secho("Created %s with password: %s" %
                     (result["message"].addr, result["message"].clear_pw))
+    elif result["status"] == "dryrun":
+        click.secho("Would create %s with password %s" %
+                    (result["message"].addr, result["message"].clear_pw))
 
 
 @click.command()

--- a/src/mailadm/commands.py
+++ b/src/mailadm/commands.py
@@ -48,6 +48,10 @@ def add_user(db, token=None, addr=None, password=None, dryrun=False) -> {}:
             return {"status": "error",
                     "message": "failed to add e-mail account {}: {}".format(addr, e)}
         user_info.clear_pw = password
+        if dryrun:
+            conn.delete_email_account(user_info.addr)
+            return {"status": "dryrun",
+                    "message": user_info}
         return {"status": "success",
                 "message": user_info}
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -134,6 +134,12 @@ class TestUsers:
         mycmd.run_ok(["del-user", addr], """
             *deleted*pytest*@x.testrun.org*
         """)
+        mycmd.run_ok(["add-user", addr, "--dryrun"], """
+            *Would create pytest*@x.testrun.org*
+        """)
+        mycmd.run_fail(["del-user", addr], """
+            *failed to delete*pytest*@x.testrun.org*does not exist*
+        """)
 
     def test_adduser_and_expire(self, mycmd, monkeypatch):
         mycmd.run_ok(["add-token", "test1", "--expiry=1d", "--prefix", "pytest."])


### PR DESCRIPTION
Just something I stumbled across while working on #46 - we can merge this afterwards, then the diff is only one commit / 14 lines.