### PR TITLE
copy only necessary things in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM docker.io/alpine:latest
 RUN apk add py3-pip py3-pillow cmake clang clang-dev make gcc g++ libc-dev linux-headers cargo openssl-dev python3-dev libffi-dev
 RUN pip install -U pip
 
-COPY . mailadm
 WORKDIR mailadm
+RUN mkdir src
+COPY setup.cfg pyproject.toml gunicorn.conf.py README.rst /mailadm/
+COPY src src/
+
 RUN pip install .

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -71,13 +71,11 @@ Now you can build and run the docker container:
 First Steps
 -----------
 
-Set Alias to Run Mailadm CLI Commands Easier (optional)
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
 ``mailadm`` CLI commands are run inside the docker container - that means that
-we need to apped ``sudo docker exec -ti mailadm mailadm`` every time. This can
-be abbreviated by running ``alias mailadm="sudo docker exec -ti mailadm mailadm"``
-once, and adding the line to your ``~/.bashrc``.
+we need to type ``sudo docker exec -ti mailadm mailadm`` in front of every
+``mailadm`` command. This can be abbreviated by running
+``alias mailadm="sudo docker exec -ti mailadm mailadm"`` once, and adding the
+line to your ``~/.bashrc``.
 
 These docs assume that you have this alias configured.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -70,13 +70,23 @@ Now you can build and run the docker container:
 
 First Steps
 -----------
-    
+
+Set Alias to Run Mailadm CLI Commands Easier (optional)
++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+``mailadm`` CLI commands are run inside the docker container - that means that
+we need to apped ``sudo docker exec -ti mailadm mailadm`` every time. This can
+be abbreviated by running ``alias mailadm="sudo docker exec -ti mailadm mailadm"``
+once, and adding the line to your ``~/.bashrc``.
+
+These docs assume that you have this alias configured.
+
 Adding a First Token and User
 +++++++++++++++++++++++++++++
 
 You can now add a first token::
 
-    $ sudo docker exec mailadm mailadm add-token oneday --expiry 1d --prefix="tmp."
+    $ mailadm add-token oneday --expiry 1d --prefix="tmp."
     added token 'oneday'
     token:oneday
       prefix = tmp.
@@ -156,7 +166,7 @@ QR Code Generation
 Once you have mailadm configured and integrated with
 nginx and mailcow, you can generate a QR code::
 
-    $ sudo docker exec mailadm mailadm gen-qr oneday
+    $ mailadm gen-qr oneday
     dcaccount-testrun.org-oneday.png written for token 'oneday'
 
 This creates a QR code in the docker container. Now we need to copy it out of


### PR DESCRIPTION
Before, we also copied the docker-data/ directory to the container, and later mounted stuff over it - it somehow worked, but it very unclean. Now only the files needed for running `pip install .` are copied.

To build, run: `sudo docker build . -t mailadm-mailcow --no-cache`, also try out the `docker run` commands to initialize and start mailadm afterwards.

Needs to be merged after #46, because gunicorn.conf.py doesn't exist yet.

related to #27 