### PR TITLE
List existing users in the bot interface

### DIFF
--- a/src/mailadm/bot.py
+++ b/src/mailadm/bot.py
@@ -72,7 +72,7 @@ class AdmBot:
             token = arguments[1] if len(arguments) > 1 else None
             with self.db.read_connection() as conn:
                 users = conn.get_user_list(token=token)
-            lines = ["%s [token: %s]" % (user.addr, user.token_name) for user in users]
+            lines = ["%s [%s]" % (user.addr, user.token_name) for user in users]
             text = "\n".join(lines)
             message.chat.send_text(text)
 

--- a/src/mailadm/bot.py
+++ b/src/mailadm/bot.py
@@ -48,6 +48,7 @@ class AdmBot:
         if arguments[0] == "/help":
             text = ("/add-token name expiry maxuse (prefix)\n"
                     "/add-user addr password token\n"
+                    "/list-users"
                     "/list-tokens")
             message.chat.send_text(text)
 

--- a/src/mailadm/bot.py
+++ b/src/mailadm/bot.py
@@ -48,7 +48,7 @@ class AdmBot:
         if arguments[0] == "/help":
             text = ("/add-token name expiry maxuse (prefix)\n"
                     "/add-user addr password token\n"
-                    "/list-users"
+                    "/list-users (token)"
                     "/list-tokens")
             message.chat.send_text(text)
 

--- a/src/mailadm/bot.py
+++ b/src/mailadm/bot.py
@@ -68,6 +68,14 @@ class AdmBot:
                 text = result.get("message")
             message.chat.send_text(text)
 
+        elif arguments[0] == "/list-users":
+            token = arguments[1] if len(arguments) > 1 else None
+            with self.db.read_connection() as conn:
+                users = conn.get_user_list(token=token)
+            lines = ["%s [token: %s]" % (user.addr, user.token_name) for user in users]
+            text = "\n".join(lines)
+            message.chat.send_text(text)
+
         elif arguments[0] == "/list-tokens":
             message.chat.send_text(list_tokens(self.db))
 

--- a/src/mailadm/cmdline.py
+++ b/src/mailadm/cmdline.py
@@ -168,7 +168,7 @@ def list_users(ctx, token):
     db = get_mailadm_db(ctx)
     with db.read_connection() as conn:
         for user_info in conn.get_user_list(token=token):
-            click.secho("{} [token={}]".format(user_info.addr, user_info.token_name))
+            click.secho("{} [{}]".format(user_info.addr, user_info.token_name))
 
 
 def dump_token_info(token_info):

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -98,7 +98,7 @@ def test_adduser_mailcow_exists(conn, mailcow):
     with pytest.raises(MailcowError):
         conn.add_email_account(token_info, addr=addr)
     for user in conn.get_user_list():
-        assert user.addr != addr
+        assert user.token_name == "created in mailcow"
 
     mailcow.del_user_mailcow(addr)
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -75,12 +75,12 @@ class TestTokenAccounts:
         assert len(expired) == 1
         assert expired[0].addr == addr2
 
-        users = conn.get_user_list()
+        users = conn.get_user_list(token="onehour")
         assert len(users) == 3
         conn.del_user_db(addr2)
         conn.commit()
-        assert len(conn.get_user_list()) == 2
-        addrs = [u.addr for u in conn.get_user_list()]
+        assert len(conn.get_user_list(token="onehour")) == 2
+        addrs = [u.addr for u in conn.get_user_list(token="onehour")]
         assert addrs == [addr, addr3]
         with pytest.raises(UserNotFound):
             conn.del_user_db(addr2)


### PR DESCRIPTION
This adds a `/list-users` bot command.

`mailadm list-users` now also includes mailcow users.