### PR TITLE
actually output the generated password

### DIFF
--- a/src/mailadm/bot.py
+++ b/src/mailadm/bot.py
@@ -63,7 +63,7 @@ class AdmBot:
             result = add_user(self.db, addr=arguments[1], password=arguments[2], token=arguments[3])
             if result.get("status") == "success":
                 user = result.get("message")
-                text = "successfully created %s with password %s" % (user.addr, user.clear_pw)
+                text = "successfully created %s with password %s" % (user.addr, user.password)
             else:
                 text = result.get("message")
             message.chat.send_text(text)

--- a/src/mailadm/cmdline.py
+++ b/src/mailadm/cmdline.py
@@ -299,10 +299,10 @@ def add_user(ctx, addr, password, token, dryrun):
         ctx.fail(result["message"])
     elif result["status"] == "success":
         click.secho("Created %s with password: %s" %
-                    (result["message"].addr, result["message"].clear_pw))
+                    (result["message"].addr, result["message"].password))
     elif result["status"] == "dryrun":
         click.secho("Would create %s with password %s" %
-                    (result["message"].addr, result["message"].clear_pw))
+                    (result["message"].addr, result["message"].password))
 
 
 @click.command()

--- a/src/mailadm/commands.py
+++ b/src/mailadm/commands.py
@@ -47,7 +47,6 @@ def add_user(db, token=None, addr=None, password=None, dryrun=False) -> {}:
         except MailcowError as e:
             return {"status": "error",
                     "message": "failed to add e-mail account {}: {}".format(addr, e)}
-        user_info.clear_pw = password
         if dryrun:
             conn.delete_email_account(user_info.addr)
             return {"status": "dryrun",


### PR DESCRIPTION
this showed up after #48 - in `commands.py::add_user()`, we accidentally set the cleartext password twice in the `user_info` object, this created some confusion in outputting the correct password to the account creator.