### PR TITLE
First working bot tests

### DIFF
--- a/src/mailadm/bot.py
+++ b/src/mailadm/bot.py
@@ -130,8 +130,9 @@ class AdmBot:
         assert sent_id == msg.id
 
 
-def get_admbot_db_path():
-    db_path = os.environ.get("ADMBOT_DB", "/mailadm/docker-data/admbot.db")
+def get_admbot_db_path(db_path=None):
+    if not db_path:
+        db_path = os.environ.get("ADMBOT_DB", "/mailadm/docker-data/admbot.db")
     try:
         sqlite3.connect(db_path)
     except sqlite3.OperationalError:
@@ -149,7 +150,7 @@ def main(mailadm_db, admbot_db_path):
         time.sleep(1)
     else:
         conn.close()
-        ac = deltachat.Account(get_admbot_db_path())
+        ac = deltachat.Account(admbot_db_path)
         ac.run_account(account_plugins=[AdmBot(mailadm_db, ac)], show_ffi=True)
     ac.wait_shutdown()
     print("shutting down bot.", file=sys.stderr)

--- a/src/mailadm/commands.py
+++ b/src/mailadm/commands.py
@@ -90,7 +90,7 @@ def prune(db, dryrun=False) -> {}:
 def list_tokens(db) -> str:
     """Print token info for all tokens
     """
-    output = []
+    output = ["Existing tokens:\n"]
     with db.read_connection() as conn:
         for name in conn.get_token_list():
             token_info = conn.get_tokeninfo_by_name(name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,7 +105,7 @@ def admbot(mailcow, db, tmpdir):
     botthread.start()
     yield botaccount
     botaccount.shutdown()
-    botthread.join(timeout=1)  # without timeout this never finishes... :/
+    botaccount.wait_shutdown()
     mailcow.del_user_mailcow(addr)
 
 
@@ -117,6 +117,7 @@ def botuser(mailcow, db, tmpdir):
     botuser = prepare_account(addr, mailcow, db_path)
     yield botuser
     botuser.shutdown()
+    botuser.wait_shutdown()
     mailcow.del_user_mailcow(addr)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,7 @@ def admingroup(admbot, botuser, db):
         time.sleep(0.1)
     chat.admbot = admbot
     chat.botuser = botuser
+    assert len(chat.get_messages()) == 5
     return chat
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ def admingroup(admbot, botuser, db):
         conn.set_config("admingrpid", admchat.id)
     qr = admchat.get_join_qr()
     chat = botuser.qr_join_chat(qr)
-    while len(chat.get_messages()) < 5:
+    while len(chat.get_messages()) < 5:  # wait for verification + welcome message
         time.sleep(0.1)
     chat.admbot = admbot
     chat.botuser = botuser

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,17 @@
-
 import os
 import pwd
 import grp
 import collections
+import threading
+from random import randint
 from pathlib import Path
 
+import deltachat
 import pytest
 from _pytest.pytester import LineMatcher
 
 import mailadm.db
+import mailadm.bot
 
 
 @pytest.fixture(autouse=True)
@@ -82,6 +85,36 @@ def cmd():
 def db(tmpdir, make_db):
     path = tmpdir.ensure("base", dir=1)
     return make_db(path)
+
+def prepare_account(addr, mailcow, db_path):
+    password = mailcow.auth["X-API-Key"]
+    mailcow.add_user_mailcow(addr, password, "admbot")
+    ac = deltachat.Account(str(db_path))
+    ac.run_account(addr, password)
+    return ac
+
+@pytest.fixture()
+def admbot(mailcow, db, tmpdir):
+    addr = "pytest-admbot-%s@x.testrun.org" % (randint(0, 999),)
+    tmpdir = Path(str(tmpdir))
+    admbot_db_path = str(mailadm.bot.get_admbot_db_path(db_path=tmpdir.joinpath("admbot.db")))
+    botaccount = prepare_account(addr, mailcow, admbot_db_path)
+    botthread = threading.Thread(target=mailadm.bot.main, args=(db, admbot_db_path), daemon=True)
+    botthread.start()
+    yield botaccount
+    botaccount.shutdown()
+    botthread.join()
+    mailcow.del_user_mailcow(addr)
+
+
+@pytest.fixture
+def botuser(mailcow, db, tmpdir):
+    addr = "pytest-%s@x.testrun.org" % (randint(0, 999),)
+    tmpdir = Path(str(tmpdir))
+    db_path = mailadm.bot.get_admbot_db_path(tmpdir.joinpath("botuser.db"))
+    botuser = prepare_account(addr, mailcow, db_path)
+    yield botuser
+    mailcow.del_user_mailcow(addr)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,11 +103,10 @@ def admingroup(admbot, botuser, db):
         conn.set_config("admingrpid", admchat.id)
     qr = admchat.get_join_qr()
     chat = botuser.qr_join_chat(qr)
-    while not chat.is_protected():
+    while len(chat.get_messages()) < 5:
         time.sleep(0.1)
     chat.admbot = admbot
     chat.botuser = botuser
-    assert len(chat.get_messages()) == 5
     return chat
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,7 @@ def prepare_account(addr, mailcow, db_path):
     password = mailcow.auth["X-API-Key"]
     mailcow.add_user_mailcow(addr, password, "admbot")
     ac = deltachat.Account(str(db_path))
+    ac._evtracker = ac.add_account_plugin(deltachat.events.FFIEventTracker(ac))
     ac.run_account(addr, password)
     return ac
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,12 +86,14 @@ def db(tmpdir, make_db):
     path = tmpdir.ensure("base", dir=1)
     return make_db(path)
 
+
 def prepare_account(addr, mailcow, db_path):
     password = mailcow.auth["X-API-Key"]
     mailcow.add_user_mailcow(addr, password, "admbot")
     ac = deltachat.Account(str(db_path))
     ac.run_account(addr, password)
     return ac
+
 
 @pytest.fixture()
 def admbot(mailcow, db, tmpdir):
@@ -103,7 +105,7 @@ def admbot(mailcow, db, tmpdir):
     botthread.start()
     yield botaccount
     botaccount.shutdown()
-    botthread.join()
+    botthread.join(timeout=1)  # without timeout this never finishes... :/
     mailcow.del_user_mailcow(addr)
 
 
@@ -114,6 +116,7 @@ def botuser(mailcow, db, tmpdir):
     db_path = mailadm.bot.get_admbot_db_path(tmpdir.joinpath("botuser.db"))
     botuser = prepare_account(addr, mailcow, db_path)
     yield botuser
+    botuser.shutdown()
     mailcow.del_user_mailcow(addr)
 
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -5,8 +5,8 @@ import pytest
 TIMEOUT = 60
 
 
+@pytest.mark.timeout(TIMEOUT)
 class TestAdminGroup:
-    @pytest.mark.timeout(TIMEOUT)
     def test_help(self, admingroup):
         num_msgs = len(admingroup.get_messages())
         admingroup.send_text("/help")
@@ -15,7 +15,6 @@ class TestAdminGroup:
         reply = admingroup.get_messages()[num_msgs + 1]
         assert reply.text.startswith("/add-user addr password token")
 
-    @pytest.mark.timeout(TIMEOUT)
     def test_list_tokens(self, admingroup):
         num_msgs = len(admingroup.get_messages())
         command = admingroup.send_text("/list-tokens")
@@ -25,7 +24,6 @@ class TestAdminGroup:
         assert reply.text.startswith("Existing tokens:")
         assert reply.quote == command
 
-    @pytest.mark.timeout(TIMEOUT)
     def test_check_privileges(self, admingroup):
         direct = admingroup.botuser.create_chat(admingroup.admbot.get_config("addr"))
         direct.send_text("/list-tokens")

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2,6 +2,9 @@ import time
 import pytest
 
 
+TIMEOUT = 30
+
+
 class TestAdminGroup:
     def create_admingroup(self, admbot, botuser, db):
         admchat = admbot.create_group_chat("admins", [], verified=True)
@@ -19,8 +22,8 @@ class TestAdminGroup:
         begin = time.time()
         while len(admingroup.get_messages()) < 7:
             time.sleep(0.1)
-            if time.time() > begin + 20:
-                pytest.fail("Bot reply took more than 20 seconds")
+            if time.time() > begin + TIMEOUT:
+                pytest.fail("Bot reply took more than %s seconds" % (TIMEOUT,))
         assert admingroup.get_messages()[6].text.startswith("/add-user addr password token")
 
     def test_list_tokens(self, admbot, botuser, db):
@@ -29,8 +32,8 @@ class TestAdminGroup:
         begin = time.time()
         while len(admingroup.get_messages()) < 7:  # this sometimes never completes
             time.sleep(0.1)
-            if time.time() > begin + 20:
-                pytest.fail("Bot reply took more than 20 seconds")
+            if time.time() > begin + TIMEOUT:
+                pytest.fail("Bot reply took more than %s seconds" % (TIMEOUT,))
         assert admingroup.get_messages()[6].text.startswith("Existing tokens:")
         #assert admingroup.get_messages()[6].quote == command  # wait for #53
 
@@ -41,6 +44,6 @@ class TestAdminGroup:
         begin = time.time()
         while len(direct.get_messages()) < 2:  # this sometimes never completes
             time.sleep(0.1)
-            if time.time() > begin + 20:
-                pytest.fail("Bot reply took more than 20 seconds")
+            if time.time() > begin + TIMEOUT:
+                pytest.fail("Bot reply took more than %s seconds" % (TIMEOUT,))
         assert direct.get_messages()[1].text == "Sorry, I only take commands from the admin group."

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,4 +1,5 @@
-from time import sleep
+import time
+import pytest
 
 
 class TestAdminGroup:
@@ -9,21 +10,27 @@ class TestAdminGroup:
         qr = admchat.get_join_qr()
         chat = botuser.qr_join_chat(qr)
         while not chat.is_protected():
-            sleep(0.1)
+            time.sleep(0.1)
         return chat
 
     def test_help(self, admbot, botuser, db):
         admingroup = self.create_admingroup(admbot, botuser, db)
         admingroup.send_text("/help")
-        while len(admingroup.get_messages()) < 7:  # this sometimes never completes
-            sleep(0.1)
+        begin = time.time()
+        while len(admingroup.get_messages()) < 7:
+            time.sleep(0.1)
+            if time.time() > begin + 20:
+                pytest.fail("Bot reply took more than 20 seconds")
         assert admingroup.get_messages()[6].text.startswith("/add-user addr password token")
 
     def test_list_tokens(self, admbot, botuser, db):
         admingroup = self.create_admingroup(admbot, botuser, db)
         command = admingroup.send_text("/list-tokens")
+        begin = time.time()
         while len(admingroup.get_messages()) < 7:  # this sometimes never completes
-            sleep(0.1)
+            time.sleep(0.1)
+            if time.time() > begin + 20:
+                pytest.fail("Bot reply took more than 20 seconds")
         assert admingroup.get_messages()[6].text.startswith("Existing tokens:")
         #assert admingroup.get_messages()[6].quote == command  # wait for #53
 
@@ -31,6 +38,9 @@ class TestAdminGroup:
         self.create_admingroup(admbot, botuser, db)
         direct = botuser.create_chat(admbot.get_config("addr"))
         direct.send_text("/list-tokens")
+        begin = time.time()
         while len(direct.get_messages()) < 2:  # this sometimes never completes
-            sleep(0.1)
+            time.sleep(0.1)
+            if time.time() > begin + 20:
+                pytest.fail("Bot reply took more than 20 seconds")
         assert direct.get_messages()[1].text == "Sorry, I only take commands from the admin group."

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -18,12 +18,12 @@ class TestAdminGroup:
     @pytest.mark.timeout(TIMEOUT)
     def test_list_tokens(self, admingroup):
         num_msgs = len(admingroup.get_messages())
-        admingroup.send_text("/list-tokens")  # command =
+        command = admingroup.send_text("/list-tokens")
         while len(admingroup.get_messages()) < num_msgs + 2:  # this sometimes never completes
             time.sleep(0.1)
         reply = admingroup.get_messages()[num_msgs + 1]
         assert reply.text.startswith("Existing tokens:")
-        # assert reply.quote == command  # wait for #53
+        assert reply.quote == command
 
     @pytest.mark.timeout(TIMEOUT)
     def test_check_privileges(self, admingroup):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -28,14 +28,14 @@ class TestAdminGroup:
 
     def test_list_tokens(self, admbot, botuser, db):
         admingroup = self.create_admingroup(admbot, botuser, db)
-        command = admingroup.send_text("/list-tokens")
+        admingroup.send_text("/list-tokens")  # command =
         begin = time.time()
         while len(admingroup.get_messages()) < 7:  # this sometimes never completes
             time.sleep(0.1)
             if time.time() > begin + TIMEOUT:
                 pytest.fail("Bot reply took more than %s seconds" % (TIMEOUT,))
         assert admingroup.get_messages()[6].text.startswith("Existing tokens:")
-        #assert admingroup.get_messages()[6].quote == command  # wait for #53
+        # assert admingroup.get_messages()[6].quote == command  # wait for #53
 
     def test_check_privileges(self, admbot, botuser, db):
         self.create_admingroup(admbot, botuser, db)
@@ -44,6 +44,6 @@ class TestAdminGroup:
         begin = time.time()
         while len(direct.get_messages()) < 2:  # this sometimes never completes
             time.sleep(0.1)
-            if time.time() > begin + TIMEOUT:
-                pytest.fail("Bot reply took more than %s seconds" % (TIMEOUT,))
+            if time.time() > begin + TIMEOUT + 10:  # this can take a bit longer, no problem
+                pytest.fail("Bot reply took more than %s seconds" % (TIMEOUT + 10,))
         assert direct.get_messages()[1].text == "Sorry, I only take commands from the admin group."

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1,0 +1,33 @@
+from time import sleep
+
+
+class TestAdminGroup:
+    def create_admingroup(self, admbot, botuser, db):
+        admchat = admbot.create_group_chat("admins", [], verified=True)
+        with db.write_transaction() as conn:
+            conn.set_config("admingrpid", admchat.id)
+        qr = admchat.get_join_qr()
+        chat = botuser.qr_join_chat(qr)
+        while not chat.is_protected():
+            sleep(0.1)
+        return chat
+
+
+    def test_help(self, admbot, botuser, db):
+        admingroup = self.create_admingroup(admbot, botuser, db)
+        admingroup.send_text("/help")
+        while len(admingroup.get_messages()) < 7:
+            sleep(0.1)
+        raise ValueError(admingroup.get_messages()[6].text)
+
+
+def test_setup_bot():
+    pass
+
+
+def test_reply():
+    pass
+
+
+def test_check_privileges():
+    pass

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2,7 +2,7 @@ import time
 import pytest
 
 
-TIMEOUT = 30
+TIMEOUT = 60
 
 
 class TestAdminGroup:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -12,22 +12,25 @@ class TestAdminGroup:
             sleep(0.1)
         return chat
 
-
     def test_help(self, admbot, botuser, db):
         admingroup = self.create_admingroup(admbot, botuser, db)
         admingroup.send_text("/help")
-        while len(admingroup.get_messages()) < 7:
+        while len(admingroup.get_messages()) < 7:  # this sometimes never completes
             sleep(0.1)
-        raise ValueError(admingroup.get_messages()[6].text)
+        assert admingroup.get_messages()[6].text.startswith("/add-user addr password token")
 
+    def test_list_tokens(self, admbot, botuser, db):
+        admingroup = self.create_admingroup(admbot, botuser, db)
+        command = admingroup.send_text("/list-tokens")
+        while len(admingroup.get_messages()) < 7:  # this sometimes never completes
+            sleep(0.1)
+        assert admingroup.get_messages()[6].text.startswith("Existing tokens:")
+        #assert admingroup.get_messages()[6].quote == command  # wait for #53
 
-def test_setup_bot():
-    pass
-
-
-def test_reply():
-    pass
-
-
-def test_check_privileges():
-    pass
+    def test_check_privileges(self, admbot, botuser, db):
+        self.create_admingroup(admbot, botuser, db)
+        direct = botuser.create_chat(admbot.get_config("addr"))
+        direct.send_text("/list-tokens")
+        while len(direct.get_messages()) < 2:  # this sometimes never completes
+            sleep(0.1)
+        assert direct.get_messages()[1].text == "Sorry, I only take commands from the admin group."

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2,7 +2,7 @@ import time
 import pytest
 
 
-TIMEOUT = 300
+TIMEOUT = 60
 
 
 class TestAdminGroup:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -7,29 +7,34 @@ TIMEOUT = 60
 
 class TestAdminGroup:
     def test_help(self, admingroup):
+        num_msgs = len(admingroup.get_messages())
         admingroup.send_text("/help")
         begin = time.time()
-        while len(admingroup.get_messages()) < 7:
+        while len(admingroup.get_messages()) < num_msgs + 2:  # this sometimes never completes
             time.sleep(0.1)
             if time.time() > begin + TIMEOUT:
                 pytest.fail("Bot reply took more than %s seconds" % (TIMEOUT,))
-        assert admingroup.get_messages()[6].text.startswith("/add-user addr password token")
+        reply = admingroup.get_messages()[num_msgs + 1]
+        assert reply.text.startswith("/add-user addr password token")
 
     def test_list_tokens(self, admingroup):
+        num_msgs = len(admingroup.get_messages())
         admingroup.send_text("/list-tokens")  # command =
         begin = time.time()
-        while len(admingroup.get_messages()) < 7:  # this sometimes never completes
+        while len(admingroup.get_messages()) < num_msgs + 2:  # this sometimes never completes
             time.sleep(0.1)
             if time.time() > begin + TIMEOUT:
                 pytest.fail("Bot reply took more than %s seconds" % (TIMEOUT,))
-        assert admingroup.get_messages()[6].text.startswith("Existing tokens:")
-        # assert admingroup.get_messages()[6].quote == command  # wait for #53
+        reply = admingroup.get_messages()[num_msgs + 2]
+        assert reply.text.startswith("Existing tokens:")
+        # assert reply.quote == command  # wait for #53
 
     def test_check_privileges(self, admingroup):
         direct = admingroup.botuser.create_chat(admingroup.admbot.get_config("addr"))
         direct.send_text("/list-tokens")
+        num_msgs = len(direct.get_messages())
         begin = time.time()
-        while len(direct.get_messages()) < 2:  # this sometimes never completes
+        while len(direct.get_messages()) == num_msgs:  # this sometimes never completes
             time.sleep(0.1)
             if time.time() > begin + TIMEOUT + 10:  # this can take a bit longer, no problem
                 pytest.fail("Bot reply took more than %s seconds" % (TIMEOUT + 10,))

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2,40 +2,34 @@ import time
 import pytest
 
 
-TIMEOUT = 60
+TIMEOUT = 300
 
 
 class TestAdminGroup:
+    @pytest.mark.timeout(TIMEOUT)
     def test_help(self, admingroup):
         num_msgs = len(admingroup.get_messages())
         admingroup.send_text("/help")
-        begin = time.time()
         while len(admingroup.get_messages()) < num_msgs + 2:  # this sometimes never completes
             time.sleep(0.1)
-            if time.time() > begin + TIMEOUT:
-                pytest.fail("Bot reply took more than %s seconds" % (TIMEOUT,))
         reply = admingroup.get_messages()[num_msgs + 1]
         assert reply.text.startswith("/add-user addr password token")
 
+    @pytest.mark.timeout(TIMEOUT)
     def test_list_tokens(self, admingroup):
         num_msgs = len(admingroup.get_messages())
         admingroup.send_text("/list-tokens")  # command =
-        begin = time.time()
         while len(admingroup.get_messages()) < num_msgs + 2:  # this sometimes never completes
             time.sleep(0.1)
-            if time.time() > begin + TIMEOUT:
-                pytest.fail("Bot reply took more than %s seconds" % (TIMEOUT,))
-        reply = admingroup.get_messages()[num_msgs + 2]
+        reply = admingroup.get_messages()[num_msgs + 1]
         assert reply.text.startswith("Existing tokens:")
         # assert reply.quote == command  # wait for #53
 
+    @pytest.mark.timeout(TIMEOUT)
     def test_check_privileges(self, admingroup):
         direct = admingroup.botuser.create_chat(admingroup.admbot.get_config("addr"))
         direct.send_text("/list-tokens")
         num_msgs = len(direct.get_messages())
-        begin = time.time()
         while len(direct.get_messages()) == num_msgs:  # this sometimes never completes
             time.sleep(0.1)
-            if time.time() > begin + TIMEOUT + 10:  # this can take a bit longer, no problem
-                pytest.fail("Bot reply took more than %s seconds" % (TIMEOUT + 10,))
         assert direct.get_messages()[1].text == "Sorry, I only take commands from the admin group."

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ skipsdist = True
 deps = 
     pytest
     pytest-xdist
+    pytest-timeout
     pdbpp
     -e .
 commands = 

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,12 @@ skipsdist = True
 
 [testenv]
 deps = 
-    pytest 
+    pytest
+    pytest-xdist
     pdbpp
-    .
+    -e .
 commands = 
-    pytest {posargs:tests}
+    pytest -n 4 {posargs:tests}
 
 [testenv:py3]
 basepython = python3


### PR DESCRIPTION
This is a start, but I'm not really satisfied:

- more tests would be nice. But what else could be tested? We don't need to test *any* command, I guess.
- test buildup and teardown takes some seconds for each test, as each test does its own admingroup creation (including a complete QR verification flow).
- I'm waiting for bot replies with a loop that sometimes never completes. Not sure how often this happens, but it doesn't look very promising and could be a general thing with the bot interface; the CLI is surely more reliable and faster. ~~We could introduce a timeout here for now, but it would make sense to keep an eye on this.~~ I added a timeout of 30 seconds; I'm tempted to measure how regularly it is reached.