### PR TITLE
mailadm setup-bot: create bot account if user didn't specify --password

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -155,13 +155,16 @@ Initializing the Bot Interface
 
 You don't have to login with SSH every time you want to create tokens. You can
 also use the bot interface to give commands to mailadm in a verified Delta
-group, the "admin group chat". The mailadm bot needs an e-mail account to
-operate - it doesn't have to be on your mailcow server, it can be any e-mail
-account which also works with Delta Chat.
+group, the "admin group chat".
 
 You can run the following command to setup the bot::
 
-    $ sudo docker exec mailadm mailadm setup-bot --email bot@example.org --password p4ssw0rd
+    $ sudo docker exec mailadm mailadm setup-bot
+
+This creates an account for the bot automatically; by default it's called
+``mailadm@yourdomain.tld``, but you can use the ``--email`` argument if you
+want to call it differently. If you want to use an existing account for the
+mailadm bot, you can specify credentials with ``--email`` and ``--password``.
 
 Then you are asked to scan a QR code to join the Admin Group, a verified Delta
 Chat group. Anyone in the group issue commands to mailadm via Delta Chat. You

--- a/src/mailadm/cmdline.py
+++ b/src/mailadm/cmdline.py
@@ -59,10 +59,11 @@ def get_mailadm_db(ctx, show=False, fail_missing_config=True):
 
 
 def create_bot_account(ctx, email: str, password=None) -> (str, str):
-    """Make sure that there is a mailcow account to use for the bot.
+    """Creates a mailcow account to use for the bot.
 
-    This method tries to use the --email and --password CLI arguments. If they are incomplete
-
+    :param email: the email address to be used for the bot account
+    :param password: you can set a custom password via CLI, auto-generated if ommitted
+    :return email, password: the credentials for the bot account
     """
     mailadmdb = get_mailadm_db(ctx)
     with mailadmdb.read_connection() as rconn:

--- a/src/mailadm/cmdline.py
+++ b/src/mailadm/cmdline.py
@@ -58,7 +58,7 @@ def get_mailadm_db(ctx, show=False, fail_missing_config=True):
     return db
 
 
-def create_bot_account(ctx, email: str, password: str) -> (str, str):
+def create_bot_account(ctx, email: str, password=None) -> (str, str):
     """Make sure that there is a mailcow account to use for the bot.
 
     This method tries to use the --email and --password CLI arguments. If they are incomplete
@@ -67,7 +67,8 @@ def create_bot_account(ctx, email: str, password: str) -> (str, str):
     mailadmdb = get_mailadm_db(ctx)
     with mailadmdb.read_connection() as rconn:
         mc = rconn.get_mailcow_connection()
-        password = mailadm.util.gen_password()
+        if not password:
+            password = mailadm.util.gen_password()
         try:
             mc.add_user_mailcow(email, password, "bot")
         except MailcowError as e:
@@ -109,14 +110,14 @@ def setup_bot(ctx, email, password, show_ffi):
         if email and not password:
             if email.split("@")[1] == mail_domain:
                 print("--password not specified, creating account automatically... ")
-                email, password = create_bot_account(ctx, email, None)
+                email, password = create_bot_account(ctx, email)
             else:
                 ctx.fail("You need to provide --password if you want to use an existing account "
                          "for the mailadm bot.")
         elif not email and not password:
             print("--email and --password not specified, creating account automatically... ")
-            email = "bot@" + mail_domain
-            email, password = create_bot_account(ctx, email, password)
+            email = "mailadm@" + mail_domain
+            email, password = create_bot_account(ctx, email, password=password)
         elif not email and password:
             ctx.fail("Please also provide --email to use an email account for the mailadm bot.")
     if email:

--- a/src/mailadm/cmdline.py
+++ b/src/mailadm/cmdline.py
@@ -24,7 +24,7 @@ from .bot import SetupPlugin, get_admbot_db_path
 
 from deltachat import Account, account_hookimpl
 from deltachat.events import FFIEventLogger
-
+from deltachat.tracker import ConfigureFailed
 
 option_dryrun = click.option(
     "-n", "--dryrun", is_flag=True,
@@ -127,7 +127,10 @@ def setup_bot(ctx, email, password, show_ffi):
     ac.set_config("sentbox_watch", "0")
     ac.set_config("bot", "1")
     configtracker = ac.configure(reconfigure=ac.is_configured())
-    configtracker.wait_finish()
+    try:
+        configtracker.wait_finish()
+    except ConfigureFailed as e:
+        ctx.fail("Authentication Failed: " + str(e))
 
     ac.start_io()
 

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -199,15 +199,15 @@ class TestSetupBot:
         print(os.environ.items())
         delete_later = True
         try:
-            mailcow.add_user_mailcow("bot@x.testrun.org", "asdf1234", "pytest")
+            mailcow.add_user_mailcow("mailadm@x.testrun.org", "asdf1234", "pytest")
         except MailcowError as e:
             if "object_exists" in str(e):
                 delete_later = False
         mycmd.run_fail(["setup-bot"], """
-            *bot@x.testrun.org already exists; delete the account in mailcow or specify*
+            *mailadm@x.testrun.org already exists; delete the account in mailcow or specify*
         """)
         if delete_later:
-            mailcow.del_user_mailcow("bot@x.testrun.org")
+            mailcow.del_user_mailcow("mailadm@x.testrun.org")
 
     def test_specify_addr_not_password(self, mycmd):
         mycmd.run_fail(["setup-bot", "--email", "bot@example.org"], """


### PR DESCRIPTION
This makes the setup-bot flow a bit more straightforward if users don't want to use an account of their own.