### PR TITLE
Warn expiring users

### DIFF
--- a/src/mailadm/app.py
+++ b/src/mailadm/app.py
@@ -31,6 +31,7 @@ def prune_loop():
             else:
                 try:
                     ac.run_account()
+                    botconfigured = True
                     continue
                 except AssertionError:
                     pass

--- a/src/mailadm/bot.py
+++ b/src/mailadm/bot.py
@@ -201,4 +201,5 @@ def main(mailadm_db, admbot_db_path):
 if __name__ == "__main__":
     mailadm_db = DB(get_db_path())
     admbot_db_path = get_admbot_db_path()
-    main(mailadm_db, admbot_db_path)
+    ac = run_bot(mailadm_db, admbot_db_path)
+    main(ac)

--- a/src/mailadm/commands.py
+++ b/src/mailadm/commands.py
@@ -66,7 +66,7 @@ def warn_expiring_users(db, admbot) -> {}:
             user = userdict["user"]
             chat = admbot.create_chat(user.addr)
             chat.send_text(userdict["message"])
-            conn.remember_warning(user)
+            conn.increment_warning_count(user)
 
 
 def prune(db, dryrun=False) -> {}:

--- a/src/mailadm/commands.py
+++ b/src/mailadm/commands.py
@@ -58,6 +58,17 @@ def add_user(db, token=None, addr=None, password=None, dryrun=False) -> {}:
                 "message": user_info}
 
 
+def warn_expiring_users(db, admbot) -> {}:
+    sysdate = int(time.time())
+    with db.write_transaction() as conn:
+        users = conn.get_users_to_warn(sysdate)
+        for userdict in users:
+            user = userdict["user"]
+            chat = admbot.create_chat(user.addr)
+            chat.send_text(userdict["message"])
+            conn.user_was_warned(user)
+
+
 def prune(db, dryrun=False) -> {}:
     sysdate = int(time.time())
     with db.write_transaction() as conn:

--- a/src/mailadm/commands.py
+++ b/src/mailadm/commands.py
@@ -66,7 +66,7 @@ def warn_expiring_users(db, admbot) -> {}:
             user = userdict["user"]
             chat = admbot.create_chat(user.addr)
             chat.send_text(userdict["message"])
-            conn.user_was_warned(user)
+            conn.remember_warning(user)
 
 
 def prune(db, dryrun=False) -> {}:

--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -236,7 +236,7 @@ class Connection:
         q = UserInfo._select_user_columns
         allusers = []
         users_to_warn = []
-        for args in self._sqlconn.execute(q, (sysdate, )).fetchall():
+        for args in self._sqlconn.execute(q).fetchall():
             allusers.append(UserInfo(*args))
         for user in allusers:
             year = 31536000

--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -245,7 +245,8 @@ class Connection:
             warnmsg = "Your account will expire in ?. You should look for an alternative email " \
                 "provider right now.\nWith Delta Chat, you can keep all your chats and " \
                 "conversations. Just use the AEAP mechanism to tell your contacts of your " \
-                "address migration: <link>\n\nYour %s team" % (self.config.mail_domain,)
+                "address migration: https://delta.chat/en/2022-09-14-aeap\n\nYour %s team" % \
+                (self.config.mail_domain,)
             if user.ttl >= year:
                 if user.warned == 0 and user.date + user.ttl < sysdate + month:
                     users_to_warn.append({"user": user, "message": warnmsg.replace("?", "30 days")})

--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -265,7 +265,10 @@ class Connection:
                     users_to_warn.append({"user": user, "message": warnmsg.replace("?", "1 day")})
             else:
                 if user.warned == 0 and user.date + user.ttl < sysdate + user.ttl / 4:
-                    timeleft = str(user.ttl / 4 / 60) + " minutes"
+                    if user.ttl > day:
+                        timeleft = str(user.ttl / 4 / 60 / 60) + " hours"
+                    else:
+                        timeleft = str(user.ttl / 4 / 60) + " minutes"
                     users_to_warn.append({"user": user, "message": warnmsg.replace("?", timeleft)})
         return users_to_warn
 

--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -269,7 +269,7 @@ class Connection:
                 users_to_warn.append({"user": user, "message": warnmsg.format(timeleft)})
         return users_to_warn
 
-    def remember_warning(self, user):
+    def increment_warning_count(self, user):
         self.execute("UPDATE users SET warned = warned + 1 WHERE addr=?", (user.addr,))
 
     def get_user_list(self, token=None):

--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -269,7 +269,7 @@ class Connection:
                 users_to_warn.append({"user": user, "message": warnmsg.format(timeleft)})
         return users_to_warn
 
-    def user_was_warned(self, user):
+    def remember_warning(self, user):
         self.execute("UPDATE users SET warned = warned + 1 WHERE addr=?", (user.addr,))
 
     def get_user_list(self, token=None):

--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -265,7 +265,7 @@ class Connection:
                         timeleft = str(int(user.ttl / 4 / 60 / 60)) + " hours"
                     else:
                         timeleft = str(int(user.ttl / 4 / 60)) + " minutes"
-            if timeleft != "":
+            if timeleft:
                 users_to_warn.append({"user": user, "message": warnmsg.format(timeleft)})
         return users_to_warn
 

--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -245,7 +245,7 @@ class Connection:
             day = 86400
             warnmsg = "Your account will expire in ?. You should look for an alternative email " \
                 "provider right now.\nWith Delta Chat, you can keep all your chats and " \
-                "conversations; just use the AEAP mechanism to tell your contacts of your " \
+                "conversations. Just use the AEAP mechanism to tell your contacts of your " \
                 "address migration: <link>\n\nYour %s team" % (self.config.mail_domain,)
             if user.ttl > year:
                 if user.warned == 0 and user.date + user.ttl < sysdate + month:

--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -242,33 +242,31 @@ class Connection:
             month = 2592000
             week = 604800
             day = 86400
-            warnmsg = "Your account will expire in ?. You should look for an alternative email " \
-                "provider right now.\nWith Delta Chat, you can keep all your chats and " \
-                "conversations. Just use the AEAP mechanism to tell your contacts of your " \
-                "address migration: https://delta.chat/en/2022-09-14-aeap\n\nYour %s team" % \
-                (self.config.mail_domain,)
+            warnmsg = "Your account will expire in {}."
+            timeleft = ""
             if user.ttl >= year:
                 if user.warned == 0 and user.date + user.ttl < sysdate + month:
-                    users_to_warn.append({"user": user, "message": warnmsg.replace("?", "30 days")})
+                    timeleft = "30 days"
                 elif user.warned == 1 and user.date + user.ttl < sysdate + week:
-                    users_to_warn.append({"user": user, "message": warnmsg.replace("?", "7 days")})
+                    timeleft = "7 days"
                 elif user.warned == 2 and user.date + user.ttl < sysdate + day:
-                    users_to_warn.append({"user": user, "message": warnmsg.replace("?", "1 day")})
+                    timeleft = "1 day"
             elif user.ttl >= month:
                 if user.warned == 0 and user.date + user.ttl < sysdate + week:
-                    users_to_warn.append({"user": user, "message": warnmsg.replace("?", "7 days")})
+                    timeleft = "7 days"
                 elif user.warned == 1 and user.date + user.ttl < sysdate + day:
-                    users_to_warn.append({"user": user, "message": warnmsg.replace("?", "1 day")})
+                    timeleft = "1 day"
             elif user.ttl >= week:
                 if user.warned == 0 and user.date + user.ttl < sysdate + day:
-                    users_to_warn.append({"user": user, "message": warnmsg.replace("?", "1 day")})
+                    timeleft = "1 day"
             else:
                 if user.warned == 0 and user.date + user.ttl < sysdate + user.ttl / 4:
                     if user.ttl > day:
                         timeleft = str(int(user.ttl / 4 / 60 / 60)) + " hours"
                     else:
                         timeleft = str(int(user.ttl / 4 / 60)) + " minutes"
-                    users_to_warn.append({"user": user, "message": warnmsg.replace("?", timeleft)})
+            if timeleft != "":
+                users_to_warn.append({"user": user, "message": warnmsg.format(timeleft)})
         return users_to_warn
 
     def user_was_warned(self, user):

--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -243,11 +243,10 @@ class Connection:
             month = 2592000
             week = 2592000
             day = 86400
-            warnmsg = """Your account will expire in ?. You should look for an alternative email
-                provider right now. With Delta Chat, you can keep all your chats and conversations;
-                just use the AEAP mechanism to tell your contacts of your address migration: <link>
-
-                Your %s team""" % (self.config.mail_domain,)
+            warnmsg = "Your account will expire in ?. You should look for an alternative email " \
+                "provider right now.\nWith Delta Chat, you can keep all your chats and " \
+                "conversations; just use the AEAP mechanism to tell your contacts of your " \
+                "address migration: <link>\n\nYour %s team" % (self.config.mail_domain,)
             if user.ttl > year:
                 if user.warned == 0 and user.date + user.ttl < sysdate + month:
                     users_to_warn.append({"user": user, "message": warnmsg.replace("?", "30 days")})
@@ -266,9 +265,9 @@ class Connection:
             else:
                 if user.warned == 0 and user.date + user.ttl < sysdate + user.ttl / 4:
                     if user.ttl > day:
-                        timeleft = str(user.ttl / 4 / 60 / 60) + " hours"
+                        timeleft = str(int(user.ttl / 4 / 60 / 60)) + " hours"
                     else:
-                        timeleft = str(user.ttl / 4 / 60) + " minutes"
+                        timeleft = str(int(user.ttl / 4 / 60)) + " minutes"
                     users_to_warn.append({"user": user, "message": warnmsg.replace("?", timeleft)})
         return users_to_warn
 

--- a/src/mailadm/db.py
+++ b/src/mailadm/db.py
@@ -106,6 +106,7 @@ class DB:
                     date INTEGER,
                     ttl INTEGER,
                     token_name TEXT NOT NULL,
+                    warned INTEGER default 0,
                     FOREIGN KEY (token_name) REFERENCES tokens (name)
                 )
             """)

--- a/src/mailadm/util.py
+++ b/src/mailadm/util.py
@@ -21,7 +21,11 @@ def parse_expiry_code(code):
         raise ValueError("expiry codes are at least 2 characters")
     val = int(code[:-1])
     c = code[-1]
-    if c == "w":
+    if c == "y":
+        return val * 365 * 24 * 60 * 60
+    elif c == "m":
+        return val * 30 * 24 * 60 * 60
+    elif c == "w":
         return val * 7 * 24 * 60 * 60
     elif c == "d":
         return val * 24 * 60 * 60

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -5,6 +5,7 @@ import time
 import mailadm
 from mailadm.conn import DBError
 from mailadm.mailcow import MailcowError
+from mailadm.util import parse_expiry_code
 
 
 @pytest.fixture
@@ -131,7 +132,7 @@ def test_users_to_warn(conn, monkeypatch):
 
     sysdate = int(time.time())
     # add 20 hours to time
-    sysdate += 60 * 60 * 20
+    sysdate += parse_expiry_code("20h")
     users = conn.get_users_to_warn(sysdate)
     assert len(users) == 1
     assert "360 minutes" in users[0]["message"]
@@ -141,7 +142,7 @@ def test_users_to_warn(conn, monkeypatch):
     expired_users = conn.get_expired_users(sysdate)
     assert len(expired_users) == 0
     # add 6 days to time
-    sysdate += 60 * 60 * 24 * 6
+    sysdate += parse_expiry_code("6d")
     users = conn.get_users_to_warn(sysdate)
     assert len(users) == 2
     # now remember the warning
@@ -155,7 +156,7 @@ def test_users_to_warn(conn, monkeypatch):
     expired_users = conn.get_expired_users(sysdate)
     assert len(expired_users) == 1
     # add 23 days to time
-    sysdate += 60 * 60 * 24 * 23
+    sysdate += parse_expiry_code("23d")
     users = conn.get_users_to_warn(sysdate)
     assert len(users) == 1
     assert "7 days" in users[0]["message"]
@@ -165,7 +166,7 @@ def test_users_to_warn(conn, monkeypatch):
     assert len(expired_users) == 2
 
     # add 306 days to time
-    sysdate += 60 * 60 * 24 * 306
+    sysdate += parse_expiry_code("306d")
     expired_users = conn.get_expired_users(sysdate)
     assert len(expired_users) == 3
     for user in expired_users:
@@ -180,7 +181,7 @@ def test_users_to_warn(conn, monkeypatch):
     conn.increment_warning_count(users[0]["user"])
 
     # add 23 days to time
-    sysdate += 60 * 60 * 24 * 23
+    sysdate += parse_expiry_code("23d")
     users = conn.get_users_to_warn(sysdate)
     assert len(users) == 1
     assert users[0]["user"].addr == yearuser.addr
@@ -188,12 +189,12 @@ def test_users_to_warn(conn, monkeypatch):
     conn.increment_warning_count(users[0]["user"])
 
     # add 20 hours to time
-    sysdate += 60 * 60 * 20
+    sysdate += parse_expiry_code("20h")
     users = conn.get_users_to_warn(sysdate)
     assert len(users) == 0
 
     # add 6 days to time
-    sysdate += 60 * 60 * 24 * 6
+    sysdate += parse_expiry_code("6d")
     users = conn.get_users_to_warn(sysdate)
     assert len(users) == 1
     assert users[0]["user"].addr == yearuser.addr
@@ -201,7 +202,7 @@ def test_users_to_warn(conn, monkeypatch):
     conn.increment_warning_count(users[0]["user"])
 
     # add 6 days to time
-    sysdate += 60 * 60 * 24 * 6
+    sysdate += parse_expiry_code("6d")
     expired_users = conn.get_expired_users(sysdate)
     assert len(expired_users) == 1
     conn.delete_email_account(expired_users[0].addr)
@@ -215,24 +216,24 @@ def test_remember_warning(conn):
 
     sysdate = int(time.time())
     # add 20 hours to time
-    sysdate += 60 * 60 * 20
+    sysdate += parse_expiry_code("20h")
     users = conn.get_users_to_warn(sysdate)
     assert len(users) == 1
     # don't remember warning
 
     # add 1 hour to time
-    sysdate += 60 * 60
+    sysdate += parse_expiry_code("1h")
     users = conn.get_users_to_warn(sysdate)
     assert len(users) == 1
     conn.increment_warning_count(users[0]["user"])
 
     # add 1 hour to time
-    sysdate += 60 * 60
+    sysdate += parse_expiry_code("1h")
     users = conn.get_users_to_warn(sysdate)
     assert len(users) == 0
 
     # add 3 hours to time
-    sysdate += 60 * 60 * 3
+    sysdate += parse_expiry_code("3h")
     expired_users = conn.get_expired_users(sysdate)
     assert len(expired_users) == 1
     conn.delete_email_account(expired_users[0].addr)

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -211,7 +211,7 @@ def test_users_to_warn(conn, monkeypatch):
 
 def test_remember_warning(conn):
     daytoken = conn.add_token("1d", token="asdf", expiry="1d", prefix="tmp.")
-    dayuser = conn.add_email_account(daytoken)
+    conn.add_email_account(daytoken)
 
     sysdate = int(time.time())
     # add 20 hours to time

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -146,7 +146,7 @@ def test_users_to_warn(conn, monkeypatch):
     assert len(users) == 2
     # now remember the warning
     for user in users:
-        conn.user_was_warned(user["user"])
+        conn.remember_warning(user["user"])
         if user["user"].addr == weekuser.addr:
             assert "1 day" in user["message"]
     users = conn.get_users_to_warn(sysdate)
@@ -160,7 +160,7 @@ def test_users_to_warn(conn, monkeypatch):
     assert len(users) == 1
     assert "7 days" in users[0]["message"]
     assert users[0]["user"].addr == monthuser.addr
-    conn.user_was_warned(users[0]["user"])
+    conn.remember_warning(users[0]["user"])
     expired_users = conn.get_expired_users(sysdate)
     assert len(expired_users) == 2
 
@@ -177,7 +177,7 @@ def test_users_to_warn(conn, monkeypatch):
     assert len(users) == 1
     assert users[0]["user"].addr == yearuser.addr
     assert "30 days" in users[0]["message"]
-    conn.user_was_warned(users[0]["user"])
+    conn.remember_warning(users[0]["user"])
 
     # add 23 days to time
     sysdate += 60 * 60 * 24 * 23
@@ -185,7 +185,7 @@ def test_users_to_warn(conn, monkeypatch):
     assert len(users) == 1
     assert users[0]["user"].addr == yearuser.addr
     assert "7 days" in users[0]["message"]
-    conn.user_was_warned(users[0]["user"])
+    conn.remember_warning(users[0]["user"])
 
     # add 20 hours to time
     sysdate += 60 * 60 * 20
@@ -198,7 +198,7 @@ def test_users_to_warn(conn, monkeypatch):
     assert len(users) == 1
     assert users[0]["user"].addr == yearuser.addr
     assert "1 day" in users[0]["message"]
-    conn.user_was_warned(users[0]["user"])
+    conn.remember_warning(users[0]["user"])
 
     # add 6 days to time
     sysdate += 60 * 60 * 24 * 6
@@ -224,7 +224,7 @@ def test_remember_warning(conn):
     sysdate += 60 * 60
     users = conn.get_users_to_warn(sysdate)
     assert len(users) == 1
-    conn.user_was_warned(users[0]["user"])
+    conn.remember_warning(users[0]["user"])
 
     # add 1 hour to time
     sysdate += 60 * 60

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -146,7 +146,7 @@ def test_users_to_warn(conn, monkeypatch):
     assert len(users) == 2
     # now remember the warning
     for user in users:
-        conn.remember_warning(user["user"])
+        conn.increment_warning_count(user["user"])
         if user["user"].addr == weekuser.addr:
             assert "1 day" in user["message"]
     users = conn.get_users_to_warn(sysdate)
@@ -160,7 +160,7 @@ def test_users_to_warn(conn, monkeypatch):
     assert len(users) == 1
     assert "7 days" in users[0]["message"]
     assert users[0]["user"].addr == monthuser.addr
-    conn.remember_warning(users[0]["user"])
+    conn.increment_warning_count(users[0]["user"])
     expired_users = conn.get_expired_users(sysdate)
     assert len(expired_users) == 2
 
@@ -177,7 +177,7 @@ def test_users_to_warn(conn, monkeypatch):
     assert len(users) == 1
     assert users[0]["user"].addr == yearuser.addr
     assert "30 days" in users[0]["message"]
-    conn.remember_warning(users[0]["user"])
+    conn.increment_warning_count(users[0]["user"])
 
     # add 23 days to time
     sysdate += 60 * 60 * 24 * 23
@@ -185,7 +185,7 @@ def test_users_to_warn(conn, monkeypatch):
     assert len(users) == 1
     assert users[0]["user"].addr == yearuser.addr
     assert "7 days" in users[0]["message"]
-    conn.remember_warning(users[0]["user"])
+    conn.increment_warning_count(users[0]["user"])
 
     # add 20 hours to time
     sysdate += 60 * 60 * 20
@@ -198,7 +198,7 @@ def test_users_to_warn(conn, monkeypatch):
     assert len(users) == 1
     assert users[0]["user"].addr == yearuser.addr
     assert "1 day" in users[0]["message"]
-    conn.remember_warning(users[0]["user"])
+    conn.increment_warning_count(users[0]["user"])
 
     # add 6 days to time
     sysdate += 60 * 60 * 24 * 6
@@ -224,7 +224,7 @@ def test_remember_warning(conn):
     sysdate += 60 * 60
     users = conn.get_users_to_warn(sysdate)
     assert len(users) == 1
-    conn.remember_warning(users[0]["user"])
+    conn.increment_warning_count(users[0]["user"])
 
     # add 1 hour to time
     sysdate += 60 * 60

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -130,7 +130,9 @@ def test_users_to_warn(conn, monkeypatch):
     weekuser = conn.add_email_account(weektoken)
     dayuser = conn.add_email_account(daytoken)
 
-    def futuredate(code, basedate=int(time.time())):
+    basedate = int(time.time()) + 1
+
+    def futuredate(code):
         return basedate + parse_expiry_code(code)
 
     # test day user warning

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -13,6 +13,8 @@ from mailadm.util import parse_expiry_code, get_human_readable_id
     ("5h", 5 * 60 * 60),
     ("15h", 15 * 60 * 60),
     ("0h", 0),
+    ("3m", 3 * 30 * 24 * 60 * 60),
+    ("2y", 2 * 365 * 24 * 60 * 60),
 ])
 def test_parse_expiries(code, duration):
     res = parse_expiry_code(code)


### PR DESCRIPTION
closes #21 

the idea is to warn users a certain timespan *before* their accounts run out:
- if their token is 1year or longer, a month, a week, and a day before expiration date
- if their token is 1month or longer, a week and a day before expiration date
- if their token is 1week or longer, a day before expiration date
- if it's shorter than that, after 3/4 of the expiration notice, they get told how much they have left either in minutes or hours.

right now, the expiration warnings are triggered by the prune loop; this is a bit unfortunate as it means that we have to initialize another deltachat.account object for the mailadm bot, and can't reuse the bot object. Maybe that's fine, it just complicates the handling a bit.

I tried it out manually, works so far. There are 2 tests, one of them could be more minimal I guess.

Does the database migration need a test?