### PR TITLE
refine user warnings tests

### DIFF
--- a/src/mailadm/app.py
+++ b/src/mailadm/app.py
@@ -3,19 +3,26 @@ help gunicorn and other WSGI servers to instantiate a web instance of mailadm
 """
 import sys
 import os
-
+import deltachat
 from .web import create_app_from_db_path
 import time
 import threading
 from .db import get_db_path, DB
-from mailadm.commands import prune
+from mailadm.commands import prune, warn_expiring_users
 from mailadm.bot import main as run_bot
 from mailadm.bot import get_admbot_db_path
 
 
 def prune_loop():
     db = DB(get_db_path())
+    # what to do if admbot wasn't configured yet?
+    ac = deltachat.Account(get_admbot_db_path())
+    ac.run_account()
+    # how to shut down admbot account in the end?
     while 1:
+        for logmsg in warn_expiring_users(db, ac).get("message"):
+            # the file=sys.stderr seems to be necessary so the output is shown in `docker logs`
+            print(logmsg, file=sys.stderr)
         for logmsg in prune(db).get("message"):
             # the file=sys.stderr seems to be necessary so the output is shown in `docker logs`
             print(logmsg, file=sys.stderr)

--- a/src/mailadm/app.py
+++ b/src/mailadm/app.py
@@ -15,14 +15,24 @@ from mailadm.bot import get_admbot_db_path
 
 def prune_loop():
     db = DB(get_db_path())
-    # what to do if admbot wasn't configured yet?
     ac = deltachat.Account(get_admbot_db_path())
-    ac.run_account()
+    botconfigured = True
+    try:
+        ac.run_account()
+    except AssertionError:
+        botconfigured = False
     # how to shut down admbot account in the end?
     while 1:
-        for logmsg in warn_expiring_users(db, ac).get("message"):
-            # the file=sys.stderr seems to be necessary so the output is shown in `docker logs`
-            print(logmsg, file=sys.stderr)
+        if botconfigured:
+            for logmsg in warn_expiring_users(db, ac).get("message"):
+                # the file=sys.stderr seems to be necessary so the output is shown in `docker logs`
+                print(logmsg, file=sys.stderr)
+        else:
+            try:
+                ac.run_account()
+                continue
+            except AssertionError:
+                pass
         for logmsg in prune(db).get("message"):
             # the file=sys.stderr seems to be necessary so the output is shown in `docker logs`
             print(logmsg, file=sys.stderr)

--- a/src/mailadm/app.py
+++ b/src/mailadm/app.py
@@ -23,13 +23,10 @@ def prune_loop():
         botconfigured = False
     # how to shut down admbot account in the end?
     while 1:
-        if botconfigured:
-            for logmsg in warn_expiring_users(db, ac).get("message"):
-                # the file=sys.stderr seems to be necessary so the output is shown in `docker logs`
-                print(logmsg, file=sys.stderr)
-        else:
+        if not botconfigured:
             try:
                 ac.run_account()
+                botconfigured = True
                 continue
             except AssertionError:
                 pass

--- a/src/mailadm/app.py
+++ b/src/mailadm/app.py
@@ -23,16 +23,17 @@ def prune_loop():
         botconfigured = False
     # how to shut down admbot account in the end?
     while 1:
+        for logmsg in prune(db).get("message"):
+            # the file=sys.stderr seems to be necessary so the output is shown in `docker logs`
+            print(logmsg, file=sys.stderr)
         if not botconfigured:
             try:
                 ac.run_account()
                 botconfigured = True
-                continue
             except AssertionError:
-                pass
-        for logmsg in prune(db).get("message"):
-            # the file=sys.stderr seems to be necessary so the output is shown in `docker logs`
-            print(logmsg, file=sys.stderr)
+                time.sleep(600)
+                continue
+        warn_expiring_users(db, ac)
         time.sleep(600)
 
 

--- a/src/mailadm/bot.py
+++ b/src/mailadm/bot.py
@@ -116,7 +116,7 @@ def get_admbot_db_path():
     return db_path
 
 
-def main(mailadm_db, admbot_db_path):
+def run_bot(mailadm_db, admbot_db_path):
     ac = deltachat.Account(admbot_db_path)
     if not ac.is_configured():
         print("if you want to talk to mailadm with Delta Chat, please run: mailadm setup-bot",
@@ -128,7 +128,11 @@ def main(mailadm_db, admbot_db_path):
         conn.close()
         ac = deltachat.Account(get_admbot_db_path())
         ac.run_account(account_plugins=[AdmBot(mailadm_db, ac)], show_ffi=True)
-    ac.wait_shutdown()
+    return ac
+
+
+def main(account):
+    account.wait_shutdown()
     print("shutting down bot.", file=sys.stderr)
 
 

--- a/src/mailadm/commands.py
+++ b/src/mailadm/commands.py
@@ -64,7 +64,7 @@ def warn_expiring_users(db, admbot) -> {}:
             user = userdict["user"]
             chat = admbot.create_chat(user.addr)
             chat.send_text(userdict["message"])
-            conn.user_was_warned(user)
+            conn.remember_warning(user)
 
 
 def prune(db, dryrun=False) -> {}:

--- a/src/mailadm/commands.py
+++ b/src/mailadm/commands.py
@@ -56,6 +56,17 @@ def add_user(db, token=None, addr=None, password=None, dryrun=False) -> {}:
                 "message": user_info}
 
 
+def warn_expiring_users(db, admbot) -> {}:
+    sysdate = int(time.time())
+    with db.write_transaction() as conn:
+        users = conn.get_users_to_warn(sysdate)
+        for userdict in users:
+            user = userdict["user"]
+            chat = admbot.create_chat(user.addr)
+            chat.send_text(userdict["message"])
+            conn.user_was_warned(user)
+
+
 def prune(db, dryrun=False) -> {}:
     sysdate = int(time.time())
     with db.write_transaction() as conn:

--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -236,7 +236,7 @@ class Connection:
         q = UserInfo._select_user_columns
         allusers = []
         users_to_warn = []
-        for args in self._sqlconn.execute(q, (sysdate, )).fetchall():
+        for args in self._sqlconn.execute(q).fetchall():
             allusers.append(UserInfo(*args))
         for user in allusers:
             year = 31536000

--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -245,7 +245,8 @@ class Connection:
             warnmsg = "Your account will expire in ?. You should look for an alternative email " \
                 "provider right now.\nWith Delta Chat, you can keep all your chats and " \
                 "conversations. Just use the AEAP mechanism to tell your contacts of your " \
-                "address migration: <link>\n\nYour %s team" % (self.config.mail_domain,)
+                "address migration: https://delta.chat/en/2022-09-14-aeap\n\nYour %s team" % \
+                (self.config.mail_domain,)
             if user.ttl >= year:
                 if user.warned == 0 and user.date + user.ttl < sysdate + month:
                     users_to_warn.append({"user": user, "message": warnmsg.replace("?", "30 days")})

--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -265,7 +265,10 @@ class Connection:
                     users_to_warn.append({"user": user, "message": warnmsg.replace("?", "1 day")})
             else:
                 if user.warned == 0 and user.date + user.ttl < sysdate + user.ttl / 4:
-                    timeleft = str(user.ttl / 4 / 60) + " minutes"
+                    if user.ttl > day:
+                        timeleft = str(user.ttl / 4 / 60 / 60) + " hours"
+                    else:
+                        timeleft = str(user.ttl / 4 / 60) + " minutes"
                     users_to_warn.append({"user": user, "message": warnmsg.replace("?", timeleft)})
         return users_to_warn
 

--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -269,7 +269,7 @@ class Connection:
                 users_to_warn.append({"user": user, "message": warnmsg.format(timeleft)})
         return users_to_warn
 
-    def user_was_warned(self, user):
+    def remember_warning(self, user):
         self.execute("UPDATE users SET warned = warned + 1 WHERE addr=?", (user.addr,))
 
     def get_user_list(self, token=None):

--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -245,7 +245,7 @@ class Connection:
             day = 86400
             warnmsg = "Your account will expire in ?. You should look for an alternative email " \
                 "provider right now.\nWith Delta Chat, you can keep all your chats and " \
-                "conversations; just use the AEAP mechanism to tell your contacts of your " \
+                "conversations. Just use the AEAP mechanism to tell your contacts of your " \
                 "address migration: <link>\n\nYour %s team" % (self.config.mail_domain,)
             if user.ttl > year:
                 if user.warned == 0 and user.date + user.ttl < sysdate + month:

--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -242,33 +242,31 @@ class Connection:
             month = 2592000
             week = 604800
             day = 86400
-            warnmsg = "Your account will expire in ?. You should look for an alternative email " \
-                "provider right now.\nWith Delta Chat, you can keep all your chats and " \
-                "conversations. Just use the AEAP mechanism to tell your contacts of your " \
-                "address migration: https://delta.chat/en/2022-09-14-aeap\n\nYour %s team" % \
-                (self.config.mail_domain,)
+            warnmsg = "Your account will expire in {}."
+            timeleft = ""
             if user.ttl >= year:
                 if user.warned == 0 and user.date + user.ttl < sysdate + month:
-                    users_to_warn.append({"user": user, "message": warnmsg.replace("?", "30 days")})
+                    timeleft = "30 days"
                 elif user.warned == 1 and user.date + user.ttl < sysdate + week:
-                    users_to_warn.append({"user": user, "message": warnmsg.replace("?", "7 days")})
+                    timeleft = "7 days"
                 elif user.warned == 2 and user.date + user.ttl < sysdate + day:
-                    users_to_warn.append({"user": user, "message": warnmsg.replace("?", "1 day")})
+                    timeleft = "1 day"
             elif user.ttl >= month:
                 if user.warned == 0 and user.date + user.ttl < sysdate + week:
-                    users_to_warn.append({"user": user, "message": warnmsg.replace("?", "7 days")})
+                    timeleft = "7 days"
                 elif user.warned == 1 and user.date + user.ttl < sysdate + day:
-                    users_to_warn.append({"user": user, "message": warnmsg.replace("?", "1 day")})
+                    timeleft = "1 day"
             elif user.ttl >= week:
                 if user.warned == 0 and user.date + user.ttl < sysdate + day:
-                    users_to_warn.append({"user": user, "message": warnmsg.replace("?", "1 day")})
+                    timeleft = "1 day"
             else:
                 if user.warned == 0 and user.date + user.ttl < sysdate + user.ttl / 4:
                     if user.ttl > day:
                         timeleft = str(int(user.ttl / 4 / 60 / 60)) + " hours"
                     else:
                         timeleft = str(int(user.ttl / 4 / 60)) + " minutes"
-                    users_to_warn.append({"user": user, "message": warnmsg.replace("?", timeleft)})
+            if timeleft != "":
+                users_to_warn.append({"user": user, "message": warnmsg.format(timeleft)})
         return users_to_warn
 
     def user_was_warned(self, user):

--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -243,11 +243,10 @@ class Connection:
             month = 2592000
             week = 2592000
             day = 86400
-            warnmsg = """Your account will expire in ?. You should look for an alternative email
-                provider right now. With Delta Chat, you can keep all your chats and conversations;
-                just use the AEAP mechanism to tell your contacts of your address migration: <link>
-
-                Your %s team""" % (self.config.mail_domain,)
+            warnmsg = "Your account will expire in ?. You should look for an alternative email " \
+                "provider right now.\nWith Delta Chat, you can keep all your chats and " \
+                "conversations; just use the AEAP mechanism to tell your contacts of your " \
+                "address migration: <link>\n\nYour %s team" % (self.config.mail_domain,)
             if user.ttl > year:
                 if user.warned == 0 and user.date + user.ttl < sysdate + month:
                     users_to_warn.append({"user": user, "message": warnmsg.replace("?", "30 days")})
@@ -266,9 +265,9 @@ class Connection:
             else:
                 if user.warned == 0 and user.date + user.ttl < sysdate + user.ttl / 4:
                     if user.ttl > day:
-                        timeleft = str(user.ttl / 4 / 60 / 60) + " hours"
+                        timeleft = str(int(user.ttl / 4 / 60 / 60)) + " hours"
                     else:
-                        timeleft = str(user.ttl / 4 / 60) + " minutes"
+                        timeleft = str(int(user.ttl / 4 / 60)) + " minutes"
                     users_to_warn.append({"user": user, "message": warnmsg.replace("?", timeleft)})
         return users_to_warn
 

--- a/src/mailadm/db.py
+++ b/src/mailadm/db.py
@@ -106,6 +106,7 @@ class DB:
                     date INTEGER,
                     ttl INTEGER,
                     token_name TEXT NOT NULL,
+                    warned INTEGER default 0,
                     FOREIGN KEY (token_name) REFERENCES tokens (name)
                 )
             """)

--- a/src/mailadm/util.py
+++ b/src/mailadm/util.py
@@ -21,7 +21,11 @@ def parse_expiry_code(code):
         raise ValueError("expiry codes are at least 2 characters")
     val = int(code[:-1])
     c = code[-1]
-    if c == "w":
+    if c == "y":
+        return val * 365 * 24 * 60 * 60
+    elif c == "m":
+        return val * 30 * 24 * 60 * 60
+    elif c == "w":
         return val * 7 * 24 * 60 * 60
     elif c == "d":
         return val * 24 * 60 * 60

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,7 +84,7 @@ def db(tmpdir, make_db):
     return make_db(path)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def mailcow_endpoint():
     if not os.environ.get("MAILCOW_ENDPOINT"):
         if os.environ.get("MAILCOW_TOKEN"):
@@ -93,7 +93,7 @@ def mailcow_endpoint():
     return os.environ.get("MAILCOW_ENDPOINT")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def mailcow_auth():
     if not os.environ.get("MAILCOW_TOKEN"):
         pytest.skip("Please set a mailcow API Key with the environment variable MAILCOW_TOKEN")

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -211,7 +211,7 @@ def test_users_to_warn(conn, monkeypatch):
 
 def test_remember_warning(conn):
     daytoken = conn.add_token("1d", token="asdf", expiry="1d", prefix="tmp.")
-    dayuser = conn.add_email_account(daytoken)
+    conn.add_email_account(daytoken)
 
     sysdate = int(time.time())
     # add 20 hours to time

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -146,7 +146,7 @@ def test_users_to_warn(conn, monkeypatch):
     assert len(users) == 2
     # now remember the warning
     for user in users:
-        conn.user_was_warned(user["user"])
+        conn.remember_warning(user["user"])
         if user["user"].addr == weekuser.addr:
             assert "1 day" in user["message"]
     users = conn.get_users_to_warn(sysdate)
@@ -160,7 +160,7 @@ def test_users_to_warn(conn, monkeypatch):
     assert len(users) == 1
     assert "7 days" in users[0]["message"]
     assert users[0]["user"].addr == monthuser.addr
-    conn.user_was_warned(users[0]["user"])
+    conn.remember_warning(users[0]["user"])
     expired_users = conn.get_expired_users(sysdate)
     assert len(expired_users) == 2
 
@@ -177,7 +177,7 @@ def test_users_to_warn(conn, monkeypatch):
     assert len(users) == 1
     assert users[0]["user"].addr == yearuser.addr
     assert "30 days" in users[0]["message"]
-    conn.user_was_warned(users[0]["user"])
+    conn.remember_warning(users[0]["user"])
 
     # add 23 days to time
     sysdate += 60 * 60 * 24 * 23
@@ -185,7 +185,7 @@ def test_users_to_warn(conn, monkeypatch):
     assert len(users) == 1
     assert users[0]["user"].addr == yearuser.addr
     assert "7 days" in users[0]["message"]
-    conn.user_was_warned(users[0]["user"])
+    conn.remember_warning(users[0]["user"])
 
     # add 20 hours to time
     sysdate += 60 * 60 * 20
@@ -198,7 +198,7 @@ def test_users_to_warn(conn, monkeypatch):
     assert len(users) == 1
     assert users[0]["user"].addr == yearuser.addr
     assert "1 day" in users[0]["message"]
-    conn.user_was_warned(users[0]["user"])
+    conn.remember_warning(users[0]["user"])
 
     # add 6 days to time
     sysdate += 60 * 60 * 24 * 6
@@ -224,7 +224,7 @@ def test_remember_warning(conn):
     sysdate += 60 * 60
     users = conn.get_users_to_warn(sysdate)
     assert len(users) == 1
-    conn.user_was_warned(users[0]["user"])
+    conn.remember_warning(users[0]["user"])
 
     # add 1 hour to time
     sysdate += 60 * 60

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -5,6 +5,7 @@ import time
 import mailadm
 from mailadm.conn import DBError
 from mailadm.mailcow import MailcowError
+from mailadm.util import parse_expiry_code
 
 
 @pytest.fixture
@@ -129,33 +130,31 @@ def test_users_to_warn(conn, monkeypatch):
     weekuser = conn.add_email_account(weektoken)
     dayuser = conn.add_email_account(daytoken)
 
-    sysdate = int(time.time())
-    # add 20 hours to time
-    sysdate += 60 * 60 * 20
-    users = conn.get_users_to_warn(sysdate)
+    def futuredate(code, basedate=int(time.time())):
+        return basedate + parse_expiry_code(code)
+
+    # test day user warning
+    assert not conn.get_expired_users(futuredate("20h"))
+    assert conn.get_expired_users(futuredate("25h"))[0].addr == dayuser.addr
+    users = conn.get_users_to_warn(futuredate("20h"))
     assert len(users) == 1
     assert "360 minutes" in users[0]["message"]
     assert users[0]["user"].addr == dayuser.addr
-    # don't remember who was warned already
 
-    expired_users = conn.get_expired_users(sysdate)
-    assert len(expired_users) == 0
-    # add 6 days to time
-    sysdate += 60 * 60 * 24 * 6
+    # test week user warning
+    sysdate = futuredate("6d")
     users = conn.get_users_to_warn(sysdate)
     assert len(users) == 2
-    # now remember the warning
     for user in users:
         conn.remember_warning(user["user"])
         if user["user"].addr == weekuser.addr:
             assert "1 day" in user["message"]
-    users = conn.get_users_to_warn(sysdate)
-    assert len(users) == 0
-
+    assert not conn.get_users_to_warn(sysdate)
     expired_users = conn.get_expired_users(sysdate)
     assert len(expired_users) == 1
-    # add 23 days to time
-    sysdate += 60 * 60 * 24 * 23
+
+    # test month user warning
+    sysdate = futuredate("23d")
     users = conn.get_users_to_warn(sysdate)
     assert len(users) == 1
     assert "7 days" in users[0]["message"]
@@ -164,8 +163,8 @@ def test_users_to_warn(conn, monkeypatch):
     expired_users = conn.get_expired_users(sysdate)
     assert len(expired_users) == 2
 
-    # add 306 days to time
-    sysdate += 60 * 60 * 24 * 306
+    # test day/week/month expiry and yearly user warning
+    sysdate = futuredate("340d")
     expired_users = conn.get_expired_users(sysdate)
     assert len(expired_users) == 3
     for user in expired_users:
@@ -179,29 +178,25 @@ def test_users_to_warn(conn, monkeypatch):
     assert "30 days" in users[0]["message"]
     conn.remember_warning(users[0]["user"])
 
-    # add 23 days to time
-    sysdate += 60 * 60 * 24 * 23
+    sysdate = futuredate("363d")
     users = conn.get_users_to_warn(sysdate)
     assert len(users) == 1
     assert users[0]["user"].addr == yearuser.addr
     assert "7 days" in users[0]["message"]
     conn.remember_warning(users[0]["user"])
 
-    # add 20 hours to time
-    sysdate += 60 * 60 * 20
+    sysdate += parse_expiry_code("20h")
     users = conn.get_users_to_warn(sysdate)
     assert len(users) == 0
 
-    # add 6 days to time
-    sysdate += 60 * 60 * 24 * 6
+    sysdate = futuredate("364d")
     users = conn.get_users_to_warn(sysdate)
     assert len(users) == 1
     assert users[0]["user"].addr == yearuser.addr
     assert "1 day" in users[0]["message"]
     conn.remember_warning(users[0]["user"])
 
-    # add 6 days to time
-    sysdate += 60 * 60 * 24 * 6
+    sysdate = futuredate("366d")
     expired_users = conn.get_expired_users(sysdate)
     assert len(expired_users) == 1
     conn.delete_email_account(expired_users[0].addr)


### PR DESCRIPTION
some tweaks to test_users_warning readability, and a slight generaliation for fixtures (we might want to try use class/global scoped fixtures, and so it's good to mark those that are easy for session scope already) 