### PR TITLE
rework thread control

### DIFF
--- a/src/mailadm/app.py
+++ b/src/mailadm/app.py
@@ -14,28 +14,15 @@ from mailadm.bot import get_admbot_db_path
 
 
 def prune_loop():
-    db = DB(get_db_path())
-    while 1:
-        for logmsg in prune(db).get("message"):
-            # the file=sys.stderr seems to be necessary so the output is shown in `docker logs`
-            print(logmsg, file=sys.stderr)
-        time.sleep(600)
-
-
-def watcher():
-    running = 2
-    while running == 2:
-        running = 0
-        threads = threading.enumerate()
-        if "prune" in [t.getName() for t in threads]:
-            running += 1
-        else:
-            print("prune thread died, killing everything now", file=sys.stderr)
-        if "bot" in [t.getName() for t in threads]:
-            running += 1
-        else:
-            print("bot thread died, killing everything now", file=sys.stderr)
-    else:
+    try:
+        db = DB(get_db_path())
+        while 1:
+            for logmsg in prune(db).get("message"):
+                # the file=sys.stderr seems to be necessary so the output is shown in `docker logs`
+                print(logmsg, file=sys.stderr)
+            time.sleep(600)
+    finally:
+        print("prune thread died, killing everything now", file=sys.stderr)
         os._exit(1)
 
 
@@ -45,8 +32,6 @@ def init_threads():
     botthread = threading.Thread(target=run_bot, args=(DB(get_db_path()), get_admbot_db_path()),
                                  daemon=True, name="bot")
     botthread.start()
-    watcherthread = threading.Thread(target=watcher, daemon=True, name="watcher")
-    watcherthread.start()
 
 
 app = create_app_from_db_path()

--- a/src/mailadm/bot.py
+++ b/src/mailadm/bot.py
@@ -177,21 +177,25 @@ def get_admbot_db_path(db_path=None):
 
 
 def main(mailadm_db, admbot_db_path):
-    ac = deltachat.Account(admbot_db_path)
-    if not ac.is_configured():
-        print("if you want to talk to mailadm with Delta Chat, please run: mailadm setup-bot",
-              file=sys.stderr)
-    conn = mailadm_db.read_connection(closing=False)
-    while "admingrpid" not in [item[0] for item in conn.get_config_items()]:
-        time.sleep(1)
-    else:
-        displayname = conn.config.mail_domain + " administration"
-        conn.close()
-        ac.set_avatar("assets/avatar.jpg")
-        ac.run_account(account_plugins=[AdmBot(mailadm_db, ac)], show_ffi=True)
-        ac.set_config("displayname", displayname)
-    ac.wait_shutdown()
-    print("shutting down bot.", file=sys.stderr)
+    try:
+        ac = deltachat.Account(admbot_db_path)
+        if not ac.is_configured():
+            print("if you want to talk to mailadm with Delta Chat, please run: mailadm setup-bot",
+                  file=sys.stderr)
+        conn = mailadm_db.read_connection(closing=False)
+        while "admingrpid" not in [item[0] for item in conn.get_config_items()]:
+            time.sleep(1)
+        else:
+            displayname = conn.config.mail_domain + " administration"
+            conn.close()
+            ac.set_avatar("assets/avatar.jpg")
+            ac.run_account(account_plugins=[AdmBot(mailadm_db, ac)], show_ffi=True)
+            ac.set_config("displayname", displayname)
+        ac.wait_shutdown()
+        print("shutting down bot.", file=sys.stderr)
+    finally:
+        print("bot thread died, killing everything now", file=sys.stderr)
+        os._exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We realized that the watcher thread causes high CPU usage, as it doesn't have a sleep statement. Then we realized that a try/finally clause would be much easier to kill the process if any thread dies.