### PR TITLE
Do not lock the database during pruning

### DIFF
--- a/src/mailadm/commands.py
+++ b/src/mailadm/commands.py
@@ -60,7 +60,7 @@ def add_user(db, token=None, addr=None, password=None, dryrun=False) -> {}:
 
 def prune(db, dryrun=False) -> {}:
     sysdate = int(time.time())
-    with db.write_transaction() as conn:
+    with db.write_connection() as conn:
         expired_users = conn.get_expired_users(sysdate)
         if not expired_users:
             return {"status": "success",


### PR DESCRIPTION
Pruning does network requests like calling the mailcow API. Holding the database write transaction for the duration of pruning is dangerous, because it may delay creating a new account in the new_email endpoint or make it timeout.

Fixes #72