### PR TITLE
Add missing timeouts to HTTP requests

### DIFF
--- a/src/mailadm/mailcow.py
+++ b/src/mailadm/mailcow.py
@@ -50,7 +50,7 @@ class MailcowConnection:
     def get_user(self, addr):
         """HTTP Request to get a specific mailcow user (not only mailadm-generated ones)."""
         url = self.mailcow_endpoint + "get/mailbox/" + addr
-        result = r.get(url, headers=self.auth)
+        result = r.get(url, headers=self.auth, timeout=30)
         json = result.json()
         if json == {}:
             return None
@@ -62,7 +62,7 @@ class MailcowConnection:
     def get_user_list(self):
         """HTTP Request to get all mailcow users (not only mailadm-generated ones)."""
         url = self.mailcow_endpoint + "get/mailbox/all"
-        result = r.get(url, headers=self.auth)
+        result = r.get(url, headers=self.auth, timeout=30)
         json = result.json()
         if json == {}:
             return []


### PR DESCRIPTION
Without these timeouts an HTTP request may be stuck forever in case of network problems,
see https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts
> Failure to do so can cause your program to hang indefinitely