### PR TITLE
Use automatic transactions in new_email()

### DIFF
--- a/src/mailadm/web.py
+++ b/src/mailadm/web.py
@@ -24,7 +24,7 @@ def create_app_from_db(db):
             return jsonify(type="error", status_code=403,
                            reason="?t (token) parameter not specified"), 403
 
-        with db.write_transaction() as conn:
+        with db.write_connection() as conn:
             token_info = conn.get_tokeninfo_by_token(token)
             if token_info is None:
                 return jsonify(type="error", status_code=403,

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -8,11 +8,11 @@ from mailadm.util import gen_password
 
 def test_token(tmpdir, make_db):
     db = make_db(tmpdir)
-    with db.get_connection(closing=True, write=True) as conn:
+    with db._get_connection(closing=True, write=True) as conn:
         assert not conn.get_token_list()
         conn.add_token(name="oneweek", prefix="xyz", expiry="1w", maxuse=5, token="123456789012345")
         conn.commit()
-    with db.get_connection(closing=True) as conn:
+    with db._get_connection(closing=True) as conn:
         assert len(conn.get_token_list()) == 1
         entry = conn.get_tokeninfo_by_name("oneweek")
         assert entry.expiry == "1w"
@@ -37,7 +37,7 @@ class TestTokenAccounts:
     @pytest.fixture
     def conn(self, tmpdir, make_db):
         db = make_db(tmpdir.mkdir("conn"))
-        conn = db.get_connection(write=True)
+        conn = db._get_connection(write=True)
         conn.add_token(name="onehour", prefix="xyz", expiry="1h",
                        maxuse=self.MAXUSE, token="123456789012345")
         conn.commit()


### PR DESCRIPTION
This way new_email() handler does not hold a write lock on the database while attempting to request a new email account from mailcow.

Fixes #81 