### PR TITLE
Make pytest work with other mailcow instances than dc.develcow.de

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -289,7 +289,8 @@ To setup your development environment, you need to do something like this::
 
 With ``tox`` you can run the tests - many of them need access to a mailcow
 instance though. If you have access to a mailcow instance, you can pass a
-``MAILCOW_TOKEN`` and ``MAILCOW_ENDPOINT`` via the command line to run them.
+``MAILCOW_TOKEN``, ``MAIL_DOMAIN``, and ``MAILCOW_ENDPOINT`` via the command
+line to run them.
 
 Mailadm HTTP API
 ----------------

--- a/src/mailadm/mailcow.py
+++ b/src/mailadm/mailcow.py
@@ -60,6 +60,11 @@ class MailcowConnection:
             if json.get("type") == "error":
                 raise MailcowError(json)
             return MailcowUser(json)
+        # some mailcow versions return all users, even if you only ask for a specific one:
+        if type(json) == list:
+            for user in [MailcowUser(user) for user in json]:
+                if user.addr == addr:
+                    return user
 
     def get_user_list(self):
         """HTTP Request to get all mailcow users (not only mailadm-generated ones)."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,8 +114,8 @@ def admingroup(admbot, botadmin, db):
 
 
 @pytest.fixture()
-def admbot(mailcow, db, tmpdir):
-    addr = "pytest-admbot-%s@x.testrun.org" % (randint(0, 99999),)
+def admbot(mailcow, db, tmpdir, mailcow_domain):
+    addr = "pytest-admbot-%s@%s" % (randint(0, 99999), mailcow_domain)
     tmpdir = Path(str(tmpdir))
     admbot_db_path = str(mailadm.bot.get_admbot_db_path(db_path=tmpdir.joinpath("admbot.db")))
     ac = prepare_account(addr, mailcow, admbot_db_path)
@@ -128,8 +128,8 @@ def admbot(mailcow, db, tmpdir):
 
 
 @pytest.fixture
-def botadmin(mailcow, db, tmpdir):
-    addr = "pytest-admin-%s@x.testrun.org" % (randint(0, 99999),)
+def botadmin(mailcow, db, tmpdir, mailcow_domain):
+    addr = "pytest-admin-%s@%s" % (randint(0, 99999), mailcow_domain)
     tmpdir = Path(str(tmpdir))
     db_path = mailadm.bot.get_admbot_db_path(tmpdir.joinpath("botadmin.db"))
     ac = prepare_account(addr, mailcow, db_path)
@@ -140,8 +140,8 @@ def botadmin(mailcow, db, tmpdir):
 
 
 @pytest.fixture
-def supportuser(mailcow, db, tmpdir):
-    addr = "pytest-supportuser-%s@x.testrun.org" % (randint(0, 99999),)
+def supportuser(mailcow, db, tmpdir, mailcow_domain):
+    addr = "pytest-supportuser-%s@%s" % (randint(0, 99999), mailcow_domain)
     tmpdir = Path(str(tmpdir))
     db_path = mailadm.bot.get_admbot_db_path(tmpdir.joinpath("supportuser.db"))
     ac = prepare_account(addr, mailcow, db_path)
@@ -168,20 +168,25 @@ def mailcow_auth():
 
 
 @pytest.fixture
+def mailcow_domain():
+    return os.environ.get("MAILCOW_DOMAIN", "x.testrun.org")
+
+
+@pytest.fixture
 def mailcow(db):
     with db.read_connection() as conn:
         return conn.get_mailcow_connection()
 
 
 @pytest.fixture
-def make_db(monkeypatch, mailcow_auth, mailcow_endpoint):
+def make_db(monkeypatch, mailcow_auth, mailcow_endpoint, mailcow_domain):
     def make_db(basedir, init=True):
         basedir = Path(str(basedir))
         db_path = basedir.joinpath("mailadm.db")
         db = mailadm.db.DB(db_path, debug=True)
         if init:
             db.init_config(
-                mail_domain="x.testrun.org",
+                mail_domain=mailcow_domain,
                 web_endpoint="https://example.org/new_email",
                 mailcow_endpoint=mailcow_endpoint,
                 mailcow_token=mailcow_auth.get("X-API-Key"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,7 +169,7 @@ def mailcow_auth():
 
 @pytest.fixture
 def mailcow_domain():
-    return os.environ.get("MAILCOW_DOMAIN", "x.testrun.org")
+    return os.environ.get("MAIL_DOMAIN", "x.testrun.org")
 
 
 @pytest.fixture

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -7,14 +7,14 @@ from mailadm.mailcow import MailcowError
 
 
 @pytest.fixture
-def mycmd(cmd, make_db, tmpdir, monkeypatch, mailcow_domain):
+def mycmd(cmd, make_db, tmpdir, monkeypatch, mailcow_domain, mailcow_endpoint):
     db = make_db(tmpdir.mkdir("mycmd"), init=False)
     monkeypatch.setenv("MAILADM_DB", str(db.path))
     monkeypatch.setenv("ADMBOT_DB", str(tmpdir.mkdir("admbot")) + "admbot.db")
     cmd.db = db
     if os.environ["MAILCOW_TOKEN"] == "":
         raise KeyError("Please set mailcow API Key with the environment variable MAILCOW_TOKEN")
-    cmd.run_ok(["init", "--mailcow-endpoint", "https://dc.develcow.de/api/v1/",
+    cmd.run_ok(["init", "--mailcow-endpoint", mailcow_endpoint,
                 "--mail-domain", mailcow_domain,
                 "--web-endpoint", "https://example.org/new_email"])
     return cmd

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -129,8 +129,8 @@ class TestUsers:
             *Created*pytest*@*
         """)
         mycmd.run_ok(["list-users"], """
-            *pytest*@*test1*
-        """)
+            *{addr}*
+        """.format(addr=addr))
         mycmd.run_fail(["add-user", addr], """
             *failed to add*pytest* account does already exist*
         """)

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -84,10 +84,10 @@ def test_adduser_mailcow_error(db):
         assert conn.get_user_list(token=token_info.name) == []
 
 
-def test_adduser_db_error(conn, monkeypatch):
+def test_adduser_db_error(conn, monkeypatch, mailcow_domain):
     """Test that no mailcow user is created if there is a DB error"""
     token_info = conn.add_token("burner1", expiry="1w", token="1w_7wDioPeeXyZx96v3", prefix="tmp.")
-    addr = "pytest.%s@x.testrun.org" % (randint(0, 99999),)
+    addr = "pytest.%s@%s" % (randint(0, 99999), mailcow_domain)
 
     def add_user_db(*args, **kwargs):
         raise DBError
@@ -105,10 +105,10 @@ def test_adduser_db_error(conn, monkeypatch):
             assert user["username"] != addr
 
 
-def test_adduser_mailcow_exists(conn, mailcow):
+def test_adduser_mailcow_exists(conn, mailcow, mailcow_domain):
     """Test that no user is created if Mailcow user already exists"""
     token_info = conn.add_token("burner1", expiry="1w", token="1w_7wDioPeeXyZx96v3", prefix="tmp.")
-    addr = "pytest.%s@x.testrun.org" % (randint(0, 99999),)
+    addr = "pytest.%s@%s" % (randint(0, 99999), mailcow_domain)
 
     mailcow.add_user_mailcow(addr, "asdf1234", token_info.name)
     with pytest.raises(MailcowError):
@@ -119,10 +119,10 @@ def test_adduser_mailcow_exists(conn, mailcow):
     mailcow.del_user_mailcow(addr)
 
 
-def test_delete_user_mailcow_missing(conn, mailcow):
+def test_delete_user_mailcow_missing(conn, mailcow, mailcow_domain):
     """Test if a mailadm user is deleted successfully if mailcow user is already missing"""
     token_info = conn.add_token("burner1", expiry="1w", token="1w_7wDioPeeXyZx96v3", prefix="tmp.")
-    addr = "pytest.%s@x.testrun.org" % (randint(0, 99999),)
+    addr = "pytest.%s@%s" % (randint(0, 99999), mailcow_domain)
 
     conn.add_email_account(token_info, addr=addr)
     mailcow.del_user_mailcow(addr)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -10,24 +10,24 @@ def test_token(tmpdir, make_db):
     db = make_db(tmpdir)
     with db._get_connection(closing=True, write=True) as conn:
         assert not conn.get_token_list()
-        conn.add_token(name="oneweek", prefix="xyz", expiry="1w", maxuse=5, token="123456789012345")
+        conn.add_token(name="pytest:1w", prefix="xyz", expiry="1w", maxuse=5, token="1234567890123")
         conn.commit()
     with db._get_connection(closing=True) as conn:
         assert len(conn.get_token_list()) == 1
-        entry = conn.get_tokeninfo_by_name("oneweek")
+        entry = conn.get_tokeninfo_by_name("pytest:1w")
         assert entry.expiry == "1w"
         assert entry.prefix == "xyz"
         assert entry.usecount == 0
 
-        entry = conn.get_tokeninfo_by_token("123456789012345")
-        assert entry.name == "oneweek"
+        entry = conn.get_tokeninfo_by_token("1234567890123")
+        assert entry.name == "pytest:1w"
         assert entry.expiry == "1w"
         assert entry.prefix == "xyz"
         assert entry.maxuse == 5
 
     with db.write_transaction() as conn:
         assert conn.get_token_list()
-        conn.del_token(name="oneweek")
+        conn.del_token(name="pytest:1w")
         assert not conn.get_token_list()
 
 
@@ -38,7 +38,7 @@ class TestTokenAccounts:
     def conn(self, tmpdir, make_db):
         db = make_db(tmpdir.mkdir("conn"))
         conn = db._get_connection(write=True)
-        conn.add_token(name="onehour", prefix="xyz", expiry="1h",
+        conn.add_token(name="pytest:1h", prefix="xyz", expiry="1h",
                        maxuse=self.MAXUSE, token="123456789012345")
         conn.commit()
         return conn
@@ -54,9 +54,9 @@ class TestTokenAccounts:
         password = gen_password()
         for i in range(self.MAXUSE):
             addr = "tmp.%s@%s" % (i, mailcow_domain)
-            conn.add_user_db(addr=addr, date=now, ttl=60 * 60, token_name="onehour")
+            conn.add_user_db(addr=addr, date=now, ttl=60 * 60, token_name="pytest:1h")
 
-        token_info = conn.get_tokeninfo_by_name("onehour")
+        token_info = conn.get_tokeninfo_by_name("pytest:1h")
         with pytest.raises(TokenExhaustedError):
             conn.add_email_account(token_info, addr="tmp.xx@" + mailcow_domain, password=password)
 
@@ -65,23 +65,23 @@ class TestTokenAccounts:
         addr = "tmp.123@" + mailcow_domain
         addr2 = "tmp.456@" + mailcow_domain
         addr3 = "tmp.789@" + mailcow_domain
-        conn.add_user_db(addr=addr, date=now, ttl=60 * 60, token_name="onehour")
+        conn.add_user_db(addr=addr, date=now, ttl=60 * 60, token_name="pytest:1h")
         with pytest.raises(DBError):
-            conn.add_user_db(addr=addr, date=now, ttl=60 * 60, token_name="onehour")
-        conn.add_user_db(addr=addr2, date=now, ttl=30 * 60, token_name="onehour")
-        conn.add_user_db(addr=addr3, date=now, ttl=32 * 60, token_name="onehour")
+            conn.add_user_db(addr=addr, date=now, ttl=60 * 60, token_name="pytest:1h")
+        conn.add_user_db(addr=addr2, date=now, ttl=30 * 60, token_name="pytest:1h")
+        conn.add_user_db(addr=addr3, date=now, ttl=32 * 60, token_name="pytest:1h")
         conn.commit()
         expired = conn.get_expired_users(sysdate=now + 31 * 60)
         assert len(expired) == 1
         assert expired[0].addr == addr2
 
-        users = conn.get_user_list(token="onehour")
+        users = conn.get_user_list(token="pytest:1h")
         assert len(users) == 3
         conn.del_user_db(addr2)
         conn.commit()
-        assert len(conn.get_user_list(token="onehour")) == 2
-        addrs = [u.addr for u in conn.get_user_list(token="onehour")]
+        assert len(conn.get_user_list(token="pytest:1h")) == 2
+        addrs = [u.addr for u in conn.get_user_list(token="pytest:1h")]
         assert addrs == [addr, addr3]
         with pytest.raises(UserNotFoundError):
             conn.del_user_db(addr2)
-        assert conn.get_tokeninfo_by_name("onehour").usecount == 3
+        assert conn.get_tokeninfo_by_name("pytest:1h").usecount == 3

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -43,28 +43,28 @@ class TestTokenAccounts:
         conn.commit()
         return conn
 
-    def test_add_with_wrong_token(self, conn):
+    def test_add_with_wrong_token(self, conn, mailcow_domain):
         now = 10000
-        addr = "tmp.123@x.testrun.org"
+        addr = "tmp.123@" + mailcow_domain
         with pytest.raises(DBError):
             conn.add_user_db(addr=addr, date=now, ttl=60 * 60, token_name="112l3kj123123")
 
-    def test_add_maxuse(self, conn):
+    def test_add_maxuse(self, conn, mailcow_domain):
         now = 10000
         password = gen_password()
         for i in range(self.MAXUSE):
-            addr = "tmp.{}@x.testrun.org".format(i)
+            addr = "tmp.%s@%s" % (i, mailcow_domain)
             conn.add_user_db(addr=addr, date=now, ttl=60 * 60, token_name="onehour")
 
         token_info = conn.get_tokeninfo_by_name("onehour")
         with pytest.raises(TokenExhaustedError):
-            conn.add_email_account(token_info, addr="tmp.xx@x.testrun.org", password=password)
+            conn.add_email_account(token_info, addr="tmp.xx@" + mailcow_domain, password=password)
 
-    def test_add_expire_del(self, conn):
+    def test_add_expire_del(self, conn, mailcow_domain):
         now = 10000
-        addr = "tmp.123@x.testrun.org"
-        addr2 = "tmp.456@x.testrun.org"
-        addr3 = "tmp.789@x.testrun.org"
+        addr = "tmp.123@" + mailcow_domain
+        addr2 = "tmp.456@" + mailcow_domain
+        addr3 = "tmp.789@" + mailcow_domain
         conn.add_user_db(addr=addr, date=now, ttl=60 * 60, token_name="onehour")
         with pytest.raises(DBError):
             conn.add_user_db(addr=addr, date=now, ttl=60 * 60, token_name="onehour")

--- a/tests/test_mailcow.py
+++ b/tests/test_mailcow.py
@@ -8,8 +8,8 @@ class TestMailcow:
     def test_get_users(self, mailcow):
         mailcow.get_user_list()
 
-    def test_add_del_user(self, mailcow):
-        addr = "pytest.%s@x.testrun.org" % (randint(0, 99999),)
+    def test_add_del_user(self, mailcow, mailcow_domain):
+        addr = "pytest.%s@%s" % (randint(0, 99999), mailcow_domain)
         mailcow.add_user_mailcow(addr, "asdf1234", "pytest")
 
         user = mailcow.get_user(addr)
@@ -19,9 +19,9 @@ class TestMailcow:
         mailcow.del_user_mailcow(addr)
         assert mailcow.get_user(addr) is None
 
-    def test_wrong_token(self, mailcow):
+    def test_wrong_token(self, mailcow, mailcow_domain):
         mailcow.auth = {"X-API-Key": "asdf"}
-        addr = "pytest.%s@x.testrun.org" % (randint(0, 99999),)
+        addr = "pytest.%s@%s" % (randint(0, 99999), mailcow_domain)
         with pytest.raises(MailcowError):
             mailcow.get_user_list()
         with pytest.raises(MailcowError):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -7,7 +7,7 @@ import random
 def test_new_user_random(db, monkeypatch, mailcow, mailcow_domain):
     token = "12319831923123"
     with db.write_transaction() as conn:
-        conn.add_token(name="test123", token=token, prefix="pytest.", expiry="1w")
+        conn.add_token(name="pytest", token=token, prefix="pytest.", expiry="1w")
 
     app = create_app_from_db_path(db.path)
     app.debug = True

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4,7 +4,7 @@ import mailadm
 import random
 
 
-def test_new_user_random(db, monkeypatch, mailcow, mailcow_domain):
+def test_new_user_random(request, db, monkeypatch, mailcow, mailcow_domain):
     token = "12319831923123"
     with db.write_transaction() as conn:
         conn.add_token(name="pytest", token=token, prefix="pytest.", expiry="1w")
@@ -26,8 +26,10 @@ def test_new_user_random(db, monkeypatch, mailcow, mailcow_domain):
     # delete a@x.testrun.org and b@x.testrun.org in case earlier tests failed to clean them up
     user_a = "pytest.a@" + mailcow_domain
     user_b = "pytest.b@" + mailcow_domain
-    mailcow.del_user_mailcow(user_a)
-    mailcow.del_user_mailcow(user_b)
+    def clean_up_test_users():
+        mailcow.del_user_mailcow(user_a)
+        mailcow.del_user_mailcow(user_b)
+    request.addfinalizer(clean_up_test_users)
 
     chars = list("ab")
 


### PR DESCRIPTION
We had the mailcow instance hardcoded in far too many places - now dc.develcow.de/x.testrun.org is still the default, but I added `MAILCOW_ENDPOINT` and `MAIL_DOMAIN` as environment variables if you want to test it with a different mailcow.