### PR TITLE
bot: reply with error if not enough arguments to /add-token

### DIFF
--- a/src/mailadm/bot.py
+++ b/src/mailadm/bot.py
@@ -95,8 +95,15 @@ class AdmBot:
         elif arguments[0] == "/add-token":
             if len(arguments) == 4:
                 arguments.append("")  # add empty prefix
-            result = add_token(self.db, name=arguments[1], expiry=arguments[2], maxuse=arguments[3],
-                             prefix=arguments[4], token=None)
+            if len(arguments) < 4:
+                result = {"status": "error",
+                          "message": "Sorry, you need to tell me more precisely what you want. For "
+                                     "example:\n\n/list-tokens oneweek 1w 50\n\nThis would create"
+                                     "a token which creates up to 50 accounts which each are valid"
+                                     "for one week."}
+            else:
+                result = add_token(self.db, name=arguments[1], expiry=arguments[2],
+                                   maxuse=arguments[3], prefix=arguments[4], token=None)
             if result["status"] == "error":
                 return self.reply("ERROR: " + result.get("message"), message)
             text = result.get("message")

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -26,6 +26,15 @@ class TestAdminGroup:
         assert reply.text.startswith("Existing tokens:")
         assert reply.quote == command
 
+    def test_wrong_number_of_arguments(self, admingroup):
+        command = admingroup.send_text("/add-token pytest")
+        while "Sorry" not in admingroup.get_messages()[len(admingroup.get_messages()) - 1].text:
+            print(admingroup.get_messages()[len(admingroup.get_messages()) - 1].text)
+            time.sleep(1)
+        reply = admingroup.get_messages()[len(admingroup.get_messages()) - 1]
+        assert reply.quote == command
+        print(reply.text)
+
     @pytest.mark.skip("This test works in real life, but not under test conditions somehow")
     def test_check_privileges(self, admingroup):
         direct = admingroup.botadmin.create_chat(admingroup.admbot.get_config("addr"))


### PR DESCRIPTION
closes #70 

I'm not suuper happy with the UX coming out of this, but it's a start I guess. Would be nice to refactor in the future. Maybe we could have a bot which asks the user for the different arguments to commands, or which guesses what the users want instead of needing clear commands? :upside_down_face: 