### PR TITLE
Add years, minutes, and seconds as expiration times

### DIFF
--- a/src/mailadm/util.py
+++ b/src/mailadm/util.py
@@ -29,8 +29,6 @@ def parse_expiry_code(code):
         return val * 24 * 60 * 60
     elif c == "h":
         return val * 60 * 60
-    elif c == "m":
-        return val * 60
     elif c == "s":
         return val
     else:

--- a/src/mailadm/util.py
+++ b/src/mailadm/util.py
@@ -33,3 +33,5 @@ def parse_expiry_code(code):
         return val * 60
     elif c == "s":
         return val
+    else:
+        raise ValueError(c + " is not a valid time unit. Try [y]ears, [w]eeks, [d]ays, or [h]ours")

--- a/src/mailadm/util.py
+++ b/src/mailadm/util.py
@@ -21,9 +21,15 @@ def parse_expiry_code(code):
         raise ValueError("expiry codes are at least 2 characters")
     val = int(code[:-1])
     c = code[-1]
-    if c == "w":
+    if c == "y":
+        return val * 365 * 24 * 60 * 60
+    elif c == "w":
         return val * 7 * 24 * 60 * 60
     elif c == "d":
         return val * 24 * 60 * 60
     elif c == "h":
         return val * 60 * 60
+    elif c == "m":
+        return val * 60
+    elif c == "s":
+        return val

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from random import randint
 import requests
@@ -17,6 +19,14 @@ def test_token_twice(conn):
     conn.add_token("burner1", expiry="1w", token="1w_7wDioPeeXyZx96v3", prefix="pp")
     with pytest.raises(DBError):
         conn.add_token("burner2", expiry="1w", token="1w_7wDioPeeXyZx96v3", prefix="xp")
+
+
+def test_token_seconds(conn):
+    token_info = conn.add_token("pytest:seconds", expiry="1s", token="1w_7wDioPeeXyZx", prefix="xp")
+    user_info = conn.add_email_account(token_info)
+    time.sleep(2)
+    assert user_info.addr in [user_info.addr for user_info in conn.get_expired_users(time.time())]
+    conn.delete_email_account(user_info.addr)
 
 
 def test_add_del_user(conn, mailcow):

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 from random import randint
 import requests
@@ -19,14 +17,6 @@ def test_token_twice(conn):
     conn.add_token("burner1", expiry="1w", token="1w_7wDioPeeXyZx96v3", prefix="pp")
     with pytest.raises(DBError):
         conn.add_token("burner2", expiry="1w", token="1w_7wDioPeeXyZx96v3", prefix="xp")
-
-
-def test_token_seconds(conn):
-    token_info = conn.add_token("pytest:seconds", expiry="1s", token="1w_7wDioPeeXyZx", prefix="xp")
-    user_info = conn.add_email_account(token_info)
-    time.sleep(2)
-    assert user_info.addr in [user_info.addr for user_info in conn.get_expired_users(time.time())]
-    conn.delete_email_account(user_info.addr)
 
 
 def test_add_del_user(conn, mailcow):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -27,6 +27,8 @@ def test_parse_expiries_short():
 def test_parse_expiries_wrong():
     with pytest.raises(ValueError):
         parse_expiry_code("123h123d")
+    with pytest.raises(ValueError):
+        parse_expiry_code("12j")
 
 
 def test_human_readable_id():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,6 +7,7 @@ from mailadm.util import parse_expiry_code, get_human_readable_id
 
 @pytest.mark.parametrize("code,duration", [
     ("never", sys.maxsize),
+    ("2y", 2 * 365 * 24 * 60 * 60),
     ("1w", 7 * 24 * 60 * 60),
     ("2w", 2 * 7 * 24 * 60 * 60),
     ("2d", 2 * 24 * 60 * 60),

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -12,6 +12,7 @@ from mailadm.util import parse_expiry_code, get_human_readable_id
     ("2d", 2 * 24 * 60 * 60),
     ("5h", 5 * 60 * 60),
     ("15h", 15 * 60 * 60),
+    ("20s", 20),
     ("0h", 0),
 ])
 def test_parse_expiries(code, duration):


### PR DESCRIPTION
closes #77 

The main purpose of this PR is handling some cases in which users might add unexpected input - seconds will not have much use in production, as prune() is only executed every 10 minutes. But it's still interesting to keep around, as developers can trigger prune() earlier by restarting mailadm or running `mailadm prune` manually, so it's useful for testing purposes even if we can't guarantee that users are indeed created 10 seconds after their creation if their token is only giving them 10 seconds.