### PR TITLE
receive emails from non-delta users (usually support requests)

### DIFF
--- a/src/mailadm/bot.py
+++ b/src/mailadm/bot.py
@@ -214,6 +214,7 @@ def main(mailadm_db, admbot_db_path):
         ac.set_avatar("assets/avatar.jpg")
         ac.run_account(account_plugins=[AdmBot(mailadm_db, ac)], show_ffi=True)
         ac.set_config("mvbox_move", "1")
+        ac.set_config("show_emails", "2")
         ac.set_config("displayname", displayname)
         while 1:
             for logmsg in prune(mailadm_db).get("message"):


### PR DESCRIPTION
Normal mails don't reach the bot so far, therefore support requests by non-delta users get lost.

This PR enables the bot to receive and handle non-delta messages.

I wonder if there is any reason that bots have `show_emails = 0` as a default, maybe this should be added to https://github.com/deltachat/deltachat-core-rust/pull/3843 as well.