### PR TITLE
wrote test for gen_qr - failing with qrcode==7.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies
         run: |
+          sudo apt install -y libzbar0
           python -m pip install -U pip
           pip install tox tox-gh-actions
       - name: Run Tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ install_requires =
     click>=6.0
     flask
     pillow
-    qrcode<=7.3.1
+    qrcode
     gunicorn
     requests
     imapclient

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ install_requires =
     click>=6.0
     flask
     pillow
-    qrcode
+    qrcode==7.3.1
     gunicorn
     requests
     imapclient

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ install_requires =
     click>=6.0
     flask
     pillow
-    qrcode==7.3.1
+    qrcode
     gunicorn
     requests
     imapclient

--- a/tests/test_gen_qr.py
+++ b/tests/test_gen_qr.py
@@ -9,4 +9,4 @@ def test_gen_qr(db):
 
     image = gen_qr(config=config, token_info=token)
     qr_decoded = decode(image)[0]
-    assert token.token in str(qr_decoded.data)
+    assert bytes(token.get_qr_uri(), encoding="ascii") == qr_decoded.data

--- a/tests/test_gen_qr.py
+++ b/tests/test_gen_qr.py
@@ -1,0 +1,12 @@
+from mailadm.gen_qr import gen_qr
+from pyzbar.pyzbar import decode
+
+
+def test_gen_qr(db):
+    with db.write_transaction() as conn:
+        config = conn.config
+        token = conn.add_token("burner1", expiry="1w", token="1w_7wDioPeeXyZx96v3", prefix="pp")
+
+    image = gen_qr(config=config, token_info=token)
+    qr_decoded = decode(image)[0]
+    assert token.token in str(qr_decoded.data)

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     pytest
     pytest-xdist
     pytest-timeout
+    pyzbar
     pdbpp
     -e .
 commands = 


### PR DESCRIPTION
closes #105 

Version 7.4.0 of the https://pypi.org/project/qrcode/#history library has introduced a bug, resulting in all QR codes mailadm generates being unreadable. We discovered this during a live test with users, very unfortunate.

I pushed a hotfix to master this morning, pinning the qrcode version to 7.3.1 - this PR reverts the hotfix and introduces a test for our `gen_qr()` function, which was untested so far.

The test works with qrcode==7.3.1, but fails with qrcode==7.4.0. We can merge this PR as soon as the CI turns green.