### PR TITLE
Fix reconfigure error 1.107.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ zip_safe = False
 packages=find:
 include_package_data=True
 install_requires =
-    deltachat>=1.91.0
+    deltachat>=1.107.1
     click>=6.0
     flask
     pillow

--- a/src/mailadm/cmdline.py
+++ b/src/mailadm/cmdline.py
@@ -132,7 +132,7 @@ def setup_bot(ctx, email, password, show_ffi):
     ac.set_config("mvbox_move", "1")
     ac.set_config("sentbox_watch", "0")
     ac.set_config("bot", "1")
-    configtracker = ac.configure(reconfigure=ac.is_configured())
+    configtracker = ac.configure()
     try:
         configtracker.wait_finish()
     except ConfigureFailed as e:

--- a/src/mailadm/gen_qr.py
+++ b/src/mailadm/gen_qr.py
@@ -5,7 +5,6 @@ from PIL import ImageFont, ImageDraw, Image
 
 
 def gen_qr(config, token_info):
-
     info = "{prefix}******@{domain} {expiry}\n".format(
         domain=config.mail_domain, prefix=token_info.prefix, expiry=token_info.expiry
     )


### PR DESCRIPTION
The python bindings apparently deprecated the "reconfigure" keyword. Which makes sense, but requires every implementation to deprecate it as well.