### PR TITLE
document zbar testing dependency

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -284,7 +284,8 @@ To setup your development environment, you need to do something like this::
     git clone https://github.com/deltachat/mailadm
     python3 -m venv venv
     . venv/bin/activate
-    pip install pytest tox
+    pip install pytest tox pytest-xdist pytest-timeout pyzbar
+    sudo apt install -y libzbar0
     pip install .
 
 With ``tox`` you can run the tests - many of them need access to a mailcow


### PR DESCRIPTION
Just set up a development environment on a new machine and noticed that we didn't document the new testing dependency in #106. 

The CI already does this automatically in https://github.com/deltachat/mailadm/blob/master/.github/workflows/ci.yml#L17 and https://github.com/deltachat/mailadm/blob/master/tox.ini#L9 - just for human developers it was not documented yet.