### PR TITLE
Only expire unused accounts

### DIFF
--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -270,12 +270,12 @@ class Connection:
         for args in self._sqlconn.execute(q, (sysdate,)).fetchall():
             overdue_users.append(UserInfo(*args))
         for user in overdue_users:
-            # hard expire users who were supposed to live less than a month
+            # expire users who were supposed to live less than 27 days
             if user.ttl < mailadm.util.parse_expiry_code("27d"):
                 expired_users.append(user)
                 continue
             last_login = self.get_mailcow_connection().get_user(user.addr).last_login
-            # hard expire users who weren't online for longer than 25% of their TTL:
+            # expire users who weren't online for longer than 25% of their TTL:
             if sysdate - last_login > user.ttl * 0.25:
                 expired_users.append(user)
         return expired_users

--- a/src/mailadm/mailcow.py
+++ b/src/mailadm/mailcow.py
@@ -89,6 +89,7 @@ class MailcowUser(object):
     def __init__(self, json):
         self.addr = json.get("username")
         self.quota = json.get("quota")
+        self.last_login = json.get("last_imap_login")
         for tag in json.get("tags", []):
             if "mailadm:" in tag:
                 self.token = tag.removeprefix("mailadm:")

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -13,7 +13,7 @@ def mycmd(cmd, make_db, tmpdir, monkeypatch, mailcow_domain, mailcow_endpoint):
     monkeypatch.setenv("MAILADM_DB", str(db.path))
     monkeypatch.setenv("ADMBOT_DB", str(tmpdir.mkdir("admbot")) + "admbot.db")
     cmd.db = db
-    if os.environ["MAILCOW_TOKEN"] == "":
+    if not os.environ["MAILCOW_TOKEN"]:
         raise KeyError("Please set mailcow API Key with the environment variable MAILCOW_TOKEN")
     cmd.run_ok(
         [

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -194,6 +194,7 @@ def test_adduser_mailcow_exists(conn, mailcow, mailcow_domain):
         ("2y", "2y", "20d", False),
         ("2y", "1d", "30w", True),
         ("90d", "30d", "2d", False),
+        ("30d", "2y", "1w", False),
     ],
 )
 def test_soft_expiry(

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -192,12 +192,21 @@ def test_adduser_mailcow_exists(conn, mailcow, mailcow_domain):
         ("1s", "1s", "0s", True),
         ("5w", "2w", "1w", False),
         ("2y", "2y", "20d", False),
-        ("2y", "1d", "1y", True),
+        ("2y", "1d", "30w", True),
         ("90d", "30d", "2d", False),
     ],
 )
-def test_soft_expiry(conn, mailcow_domain, tmp_db_path, monkeypatch, expiry, time_overdue,
-                     time_since_last_login, to_be_pruned, mailcow):
+def test_soft_expiry(
+    conn,
+    mailcow_domain,
+    tmp_db_path,
+    monkeypatch,
+    expiry,
+    time_overdue,
+    time_since_last_login,
+    to_be_pruned,
+    mailcow,
+):
     """Test whether a user expires depending on last login"""
     to_expire = time.time() - parse_expiry_code(expiry) - parse_expiry_code(time_overdue)
     # create an account which is living for longer than its expiry time so far


### PR DESCRIPTION
This PR introduces soft expiry according to https://github.com/deltachat/mailadm/issues/21#issuecomment-1453556526:
- It only expires accounts which have not been used in the last TTL/25% time.
- Unless the accounts were supposed to live less than a month.
- This translates to a minimum inactivity of a week, before an account is deleted.

There is [a test](https://github.com/deltachat/mailadm/commit/931269b058e09a81b9cf1d8ae4cbc9438a0242fd#diff-d5df77bd49b4c8a950313bd8f304bafbd3b7e30be6bcc64aab43b949f310d96eR188-R198) which specifies in the test parameters when we expect accounts to expire and when we expect them to *not* expire. This makes it easy to change the policy in the future. Any further suggestions on test cases?

This PR does *not* introduce a limit to soft expiry - if an account was supposed to live for at least a month, and someone is accessing it at least once a week, we still keep it around. **But:** both the method and the test are written in a way that we can easily change this behavior in the future.