### PR TITLE
also ignore if chat ID is there but message can't be sent

### DIFF
--- a/src/mailadm/cmdline.py
+++ b/src/mailadm/cmdline.py
@@ -174,12 +174,7 @@ def setup_bot(ctx, email, password, show_ffi):
             )
             setupplugin.message_sent.wait()
         except ValueError as e:
-            if "cannot get chat with id=" + admingrpid_old in str(e):
-                print("Could not notify the old admin group.")
-            elif "message could not be send, does chat exist" in str(e):
-                print("Could not notify the old admin group.")
-            else:
-                raise
+            print("Could not notify the old admin group:", str(e))
         print("The old admin group was deactivated.")
     sys.stdout.flush()  # flush stdout to actually show the messages above
     ac.shutdown()

--- a/src/mailadm/cmdline.py
+++ b/src/mailadm/cmdline.py
@@ -176,6 +176,8 @@ def setup_bot(ctx, email, password, show_ffi):
         except ValueError as e:
             if "cannot get chat with id=" + admingrpid_old in str(e):
                 print("Could not notify the old admin group.")
+            elif "message could not be send, does chat exist" in str(e):
+                print("Could not notify the old admin group.")
             else:
                 raise
         print("The old admin group was deactivated.")


### PR DESCRIPTION
This error appears if you migrated the mailadm database, didn't migrate the adminbot database, and ran `mailadm setup-bot`:

```
Waiting until you join the chat
Welcome message sent.
Traceback (most recent call last):
  File "/usr/bin/mailadm", line 8, in <module>
    sys.exit(mailadm_main())
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/usr/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/lib/python3.10/site-packages/mailadm/cmdline.py", line 171, in setup_bot
    oldgroup.send_text(
  File "/usr/lib/python3.10/site-packages/deltachat/chat.py", line 311, in send_text
    raise ValueError("message could not be send, does chat exist?")
ValueError: message could not be send, does chat exist?
```

This PR fixes this crash by ignoring the error. A similar error was already escaped in exact this location, this just spits out a different error message we didn't catch yet.