### PR TITLE
fix: don't crash if user doesn't exist in mailcow

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -315,7 +315,7 @@ To setup your development environment, you need to do something like this:
     git clone https://github.com/deltachat/mailadm
     python3 -m venv venv
     . venv/bin/activate
-    pip install pytest tox pytest-xdist pytest-timeout pyzbar
+    pip install pytest tox pytest-xdist pytest-timeout pyzbar black ruff
     sudo apt install -y libzbar0
     pip install .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]
-select = [
+lint.select = [
   "E", "W", # pycodestyle
   "F", # Pyflakes
   "N", # pep8-naming
@@ -24,7 +24,7 @@ select = [
   "PLE", # Pylint Error
   "PLW", # Pylint Warning
 ]
-ignore = ["PT001", "PT016", "PT011"]
+lint.ignore = ["PT001", "PT016", "PT011"]
 line-length = 100
 
 [tool.black]

--- a/src/mailadm/app.py
+++ b/src/mailadm/app.py
@@ -1,6 +1,7 @@
 """
 help gunicorn and other WSGI servers to instantiate a web instance of mailadm
 """
+
 import threading
 
 from mailadm.bot import get_admbot_db_path

--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -275,7 +275,7 @@ class Connection:
                 expired_users.append(user)
                 continue
             mc_user = self.get_mailcow_connection().get_user(user.addr)
-            if not mc_user:
+            if mc_user is None:
                 logging.warning("user %s doesn't exist in mailcow", user.addr)
                 continue
             last_login = mc_user.last_login

--- a/src/mailadm/conn.py
+++ b/src/mailadm/conn.py
@@ -274,7 +274,11 @@ class Connection:
             if user.ttl < mailadm.util.parse_expiry_code("27d"):
                 expired_users.append(user)
                 continue
-            last_login = self.get_mailcow_connection().get_user(user.addr).last_login
+            mc_user = self.get_mailcow_connection().get_user(user.addr)
+            if not mc_user:
+                logging.warning("user %s doesn't exist in mailcow", user.addr)
+                continue
+            last_login = mc_user.last_login
             # expire users who weren't online for longer than 25% of their TTL:
             if sysdate - last_login > user.ttl * 0.25:
                 expired_users.append(user)

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ deps =
     black
 commands =
     rst-lint README.rst CHANGELOG.rst doc/index.rst
-    ruff src/ tests/
+    ruff check src/ tests/
     black --check --diff src/ tests/
 
 [testenv:check-manifest]


### PR DESCRIPTION
Fixes this annoying crash:

```
2024-04-11T12:26:09.426000639Z Traceback (most recent call last):                                                                                                                                                                            
2024-04-11T12:26:09.426011588Z   File "/usr/lib/python3.10/site-packages/mailadm/bot.py", line 270, in main                                                                                                                                  
2024-04-11T12:26:09.426021251Z     for logmsg in prune(mailadm_db).get("message"):                                                                                                                                                           
2024-04-11T12:26:09.426030978Z   File "/usr/lib/python3.10/site-packages/mailadm/commands.py", line 70, in prune                                                                                                                             
2024-04-11T12:26:09.426042245Z     expired_users = conn.get_expired_users(sysdate)                                                                                                                                                           
2024-04-11T12:26:09.426048044Z   File "/usr/lib/python3.10/site-packages/mailadm/conn.py", line 278, in get_expired_users                                                                                                                    
2024-04-11T12:26:09.426062633Z     last_login = self.get_mailcow_connection().get_user(user.addr).last_login                                                                                                                                 
2024-04-11T12:26:09.426068696Z AttributeError: 'NoneType' object has no attribute 'last_login'                                                                                                                                               
```